### PR TITLE
test: add API security tests using Bright

### DIFF
--- a/.github/workflows/bright.yml
+++ b/.github/workflows/bright.yml
@@ -28,5 +28,12 @@ jobs:
     - name: Install dependencies
       run: npm ci
 
+    - name: Install sectester
+      run: |
+        npm i --save-dev @sectester/runner \
+          @sectester/core            \
+          @sectester/repeater        \
+          @sectester/reporter        \
+          @sectester/scan
     - name: Run SecTester tests
       run: npm test -- test/routes

--- a/.github/workflows/bright.yml
+++ b/.github/workflows/bright.yml
@@ -29,4 +29,4 @@ jobs:
       run: npm ci
 
     - name: Run SecTester tests
-      run: npm test -- test/sec
+      run: npm test -- test/routes

--- a/.github/workflows/bright.yml
+++ b/.github/workflows/bright.yml
@@ -1,0 +1,32 @@
+name: Run SecTester Tests
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    env:
+      BRIGHT_HOSTNAME: app.brightsec.com
+      BRIGHT_TOKEN: ${{ secrets.BRIGHT_TOKEN }}
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
+    - name: Set up Node.js
+      uses: actions/setup-node@v2
+      with:
+        node-version: '16'
+
+    - name: Install dependencies
+      run: npm ci
+
+    - name: Run SecTester tests
+      run: npm test -- test/sec

--- a/test/routes/articles-feed.test.js
+++ b/test/routes/articles-feed.test.js
@@ -1,0 +1,47 @@
+'use strict'
+const t = require('tap')
+const { Configuration, SecRunner } = require('@sectester/runner');
+const { TestType, Severity } = require('@sectester/scan');
+const startServer = require('../setup-server')
+
+const configuration = new Configuration({ hostname: 'app.brightsec.com' });
+
+async function runSecurityTests() {
+  const runner = new SecRunner(configuration);
+  await runner.init();
+
+  const scan = runner.createScan({
+    tests: [TestType.SQLI, TestType.XSS],
+    threshold: Severity.MEDIUM,
+    timeout: 300000, // 5 minutes
+  });
+
+  const target = {
+    method: 'GET',
+    url: 'https://localhost:3000/articles/feed',
+    headers: { 'Authorization': 'Token jwt.token.here' },
+    query: { limit: 10, offset: 0 }
+  };
+
+  await scan.run(target);
+  await runner.clear();
+}
+
+runSecurityTests().catch(console.error);
+
+// Regular functional test
+
+ t.test('requests the "/articles/feed" route', async t => {
+  const server = await startServer()
+  t.teardown(() => server.close())
+
+  const response = await server.inject({
+    method: 'GET',
+    url: '/articles/feed',
+    headers: { 'Authorization': 'Token jwt.token.here' },
+    query: { limit: 10, offset: 0 }
+  })
+
+  t.equal(response.statusCode, 200, 'returns a status code of 200')
+  t.end()
+})

--- a/test/routes/articles-feed.test.js
+++ b/test/routes/articles-feed.test.js
@@ -1,6 +1,7 @@
 'use strict'
 const t = require('tap')
-const { Configuration, SecRunner } = require('@sectester/runner');
+const { Configuration } = require('@sectester/core');
+const { SecRunner } = require('@sectester/runner');
 const { TestType, Severity } = require('@sectester/scan');
 const startServer = require('../setup-server')
 

--- a/test/routes/articles.test.js
+++ b/test/routes/articles.test.js
@@ -1,7 +1,8 @@
 'use strict'
 const t = require('tap')
 const startServer = require('../setup-server')
-const { Configuration, SecRunner } = require('@sectester/runner');
+const { Configuration } = require('@sectester/core');
+const { SecRunner } = require('@sectester/runner');
 const { TestType, Severity } = require('@sectester/scan');
 
 const configuration = new Configuration({ hostname: 'app.brightsec.com' });

--- a/test/routes/articles.test.js
+++ b/test/routes/articles.test.js
@@ -1,0 +1,127 @@
+'use strict'
+const t = require('tap')
+const startServer = require('../setup-server')
+const { Configuration, SecRunner } = require('@sectester/runner');
+const { TestType, Severity } = require('@sectester/scan');
+
+const configuration = new Configuration({ hostname: 'app.brightsec.com' });
+
+const scanSettings = {
+  tests: [TestType.SQLI, TestType.XSS, TestType.BROKEN_ACCESS_CONTROL],
+  threshold: Severity.MEDIUM,
+  timeout: 300000, // 5 minutes
+};
+
+async function runSecurityTests(target) {
+  const runner = new SecRunner(configuration);
+  await runner.init();
+  const scan = runner.createScan(scanSettings);
+  await scan.run(target);
+  await runner.clear();
+}
+
+// Test for creating an article
+async function testCreateArticle(t) {
+  const server = await startServer();
+  t.teardown(() => server.close());
+
+  const target = {
+    method: 'POST',
+    url: 'https://localhost:8000/articles',
+    headers: { 'Authorization': 'Token jwt.token.here' },
+    body: { article: { title: 'string', description: 'string', body: 'string', tagList: ['string'] } }
+  };
+
+  await runSecurityTests(target);
+
+  const response = await server.inject({
+    method: 'POST',
+    url: '/api/articles',
+    headers: { 'Authorization': 'Token jwt.token.here' },
+    payload: {
+      article: {
+        title: 'string',
+        description: 'string',
+        body: 'string',
+        tagList: ['string']
+      }
+    }
+  });
+  t.equal(response.statusCode, 201, 'returns a status code of 201 Created');
+  t.end();
+}
+
+// Test for updating an article
+async function testUpdateArticle(t) {
+  const server = await startServer();
+  t.teardown(() => server.close());
+
+  const target = {
+    method: 'PUT',
+    url: 'http://localhost:3000/api/articles/test-article',
+    headers: { 'Authorization': 'Token jwt.token.here' },
+    body: {
+      article: {
+        title: 'string',
+        description: 'string',
+        body: 'string'
+      }
+    }
+  };
+
+  await runSecurityTests(target);
+
+  const response = await server.inject(target);
+  t.equal(response.statusCode, 200, 'returns a status code of 200 OK');
+  t.end();
+}
+
+// Test for deleting an article with invalid token
+async function testDeleteArticleInvalidToken(t) {
+  const server = await startServer();
+  t.teardown(() => server.close());
+
+  const target = {
+    method: 'DELETE',
+    url: 'https://localhost:3000/articles/{slug}',
+    headers: { Authorization: 'Token jwt.token.here' }
+  };
+
+  await runSecurityTests(target);
+
+  const response = await server.inject({
+    method: 'DELETE',
+    url: '/api/articles/test-article',
+    headers: { Authorization: 'Token invalid.token.here' }
+  });
+  t.equal(response.statusCode, 401, 'returns a status code of 401 Unauthorized');
+  t.end();
+}
+
+// Test for deleting article favorite without authorization
+async function testDeleteArticleFavorite(t) {
+  const server = await startServer();
+  t.teardown(() => server.close());
+
+  const target = {
+    method: 'DELETE',
+    url: 'http://localhost:3000/articles/{slug}/favorite',
+    headers: { Authorization: 'Token jwt.token.here' }
+  };
+
+  await runSecurityTests(target);
+
+  const response = await server.inject({
+    method: 'DELETE',
+    url: '/articles/{slug}/favorite',
+    headers: { Authorization: 'Token jwt.token.here' }
+  });
+  t.equal(response.statusCode, 401, 'returns a status code of 401 Unauthorized');
+  t.end();
+}
+
+// Run all tests
+t.test('create article with SQLi and XSS tests', testCreateArticle);
+t.test('update article with potential vulnerabilities', testUpdateArticle);
+t.test('delete article with invalid token', testDeleteArticleInvalidToken);
+t.test('delete article favorite without authorization', testDeleteArticleFavorite);

--- a/test/routes/comments-delete.test.js
+++ b/test/routes/comments-delete.test.js
@@ -1,0 +1,31 @@
+'use strict'
+const t = require('tap')
+const startServer = require('../setup-server')
+const { SecRunner, TestType, Severity } = require('@sectester/runner')
+
+const configuration = { hostname: 'app.brightsec.com' }
+
+// Test for DELETE /articles/example-article/comments/1
+
+t.test('DELETE /articles/example-article/comments/1 should not have broken access control', async t => {
+  const server = await startServer()
+  t.teardown(() => server.close())
+
+  const runner = new SecRunner(configuration)
+  await runner.init()
+
+  const scan = runner.createScan({
+    tests: [TestType.BROKEN_ACCESS_CONTROL],
+    threshold: Severity.MEDIUM,
+    timeout: 300000 // 5 minutes
+  })
+
+  await scan.run({
+    method: 'DELETE',
+    url: 'https://localhost:8000/articles/example-article/comments/1',
+    headers: { Authorization: 'Bearer <token>' }
+  })
+
+  await runner.clear()
+  t.end()
+})

--- a/test/routes/comments.test.js
+++ b/test/routes/comments.test.js
@@ -1,6 +1,7 @@
 'use strict'
 const t = require('tap');
-const { Configuration, SecRunner } = require('@sectester/runner');
+const { Configuration } = require('@sectester/core');
+const { SecRunner } = require('@sectester/runner');
 const { TestType, Severity } = require('@sectester/scan');
 const startServer = require('../setup-server');
 

--- a/test/routes/comments.test.js
+++ b/test/routes/comments.test.js
@@ -1,0 +1,58 @@
+'use strict'
+const t = require('tap');
+const { Configuration, SecRunner } = require('@sectester/runner');
+const { TestType, Severity } = require('@sectester/scan');
+const startServer = require('../setup-server');
+
+const configuration = new Configuration({ hostname: 'app.brightsec.com' });
+
+async function runSecurityTests() {
+  const runner = new SecRunner(configuration);
+  await runner.init();
+
+  const scan = runner.createScan({
+    tests: [TestType.XSS, TestType.SQLI],
+    threshold: Severity.MEDIUM,
+    timeout: 300000, // 5 minutes
+  });
+
+  const server = await startServer();
+
+  // Test case 1: GET request
+  await scan.run({
+    method: 'GET',
+    url: 'http://localhost:3000/articles/example-article/comments'
+  });
+
+  // Test case 2: POST request
+  await scan.run({
+    method: 'POST',
+    url: 'https://localhost:8000/articles/example-article/comments',
+    headers: { 'Authorization': 'Bearer <token>' },
+    body: { comment: { body: 'This is a comment.' } }
+  });
+
+  await runner.clear();
+  server.close();
+}
+
+runSecurityTests().catch(err => {
+  console.error(err);
+  process.exit(1);
+});
+
+// TAP test for POST request
+t.test('post comment with security tests', async t => {
+  const server = await startServer();
+  t.teardown(() => server.close());
+
+  const response = await server.inject({
+    method: 'POST',
+    url: '/articles/example-article/comments',
+    headers: { 'Authorization': 'Bearer <token>' },
+    payload: { comment: { body: 'This is a comment.' } }
+  });
+
+  t.equal(response.statusCode, 200, 'returns a status code of 200 OK');
+  t.end();
+});

--- a/test/routes/profiles.test.js
+++ b/test/routes/profiles.test.js
@@ -1,6 +1,7 @@
 'use strict'
 const t = require('tap')
-const { Configuration, SecRunner } = require('@sectester/runner');
+const { Configuration } = require('@sectester/core');
+const { SecRunner } = require('@sectester/runner');```
 const { TestType, Severity } = require('@sectester/scan');
 const startServer = require('../setup-server')
 

--- a/test/routes/profiles.test.js
+++ b/test/routes/profiles.test.js
@@ -1,0 +1,99 @@
+'use strict'
+const t = require('tap')
+const { Configuration, SecRunner } = require('@sectester/runner');
+const { TestType, Severity } = require('@sectester/scan');
+const startServer = require('../setup-server')
+
+const configuration = new Configuration({ hostname: 'app.brightsec.com' });
+
+let runner;
+
+async function setupRunner() {
+  runner = new SecRunner(configuration);
+  await runner.init();
+}
+
+async function teardownRunner() {
+  await runner.clear();
+}
+
+async function runSecurityTestXSS() {
+  const scan = runner.createScan({
+    tests: [TestType.XSS],
+    threshold: Severity.MEDIUM,
+    timeout: 300000, // 5 minutes
+  });
+
+  await scan.run({
+    method: 'GET',
+    url: 'http://localhost:3000/profiles/johndoe',
+  });
+}
+
+async function runSecurityTestBrokenAccessControl(method, url) {
+  const scan = runner.createScan({
+    tests: [TestType.BROKEN_ACCESS_CONTROL],
+    threshold: Severity.MEDIUM,
+    timeout: 300000, // 5 minutes
+  });
+
+  await scan.run({
+    method: method,
+    url: url,
+    headers: { Authorization: 'Bearer <token>' },
+  });
+}
+
+setupRunner();
+
+// Test for XSS vulnerability on the /profiles/johndoe endpoint
+
+t.test('GET /profiles/johndoe for XSS', async t => {
+  const server = await startServer()
+  t.teardown(() => server.close())
+
+  const response = await server.inject({
+    method: 'GET',
+    url: '/profiles/johndoe'
+  })
+  t.equal(response.statusCode, 200, 'returns a status code of 200 OK')
+
+  await runSecurityTestXSS();
+
+  t.end()
+})
+
+// Test for broken access control on the /profiles/johndoe/follow endpoint
+
+t.test('POST /profiles/johndoe/follow without login', async t => {
+  const server = await startServer()
+  t.teardown(() => server.close())
+
+  const response = await server.inject({
+    method: 'POST',
+    url: '/profiles/johndoe/follow'
+  })
+  t.equal(response.statusCode, 401, 'returns a status code of 401 Unauthorized')
+
+  await runSecurityTestBrokenAccessControl('POST', 'https://localhost:3000/profiles/johndoe/follow');
+
+  t.end()
+})
+
+t.test('DELETE /profiles/johndoe/follow without proper authorization', async t => {
+  const server = await startServer()
+  t.teardown(() => server.close())
+
+  const response = await server.inject({
+    method: 'DELETE',
+    url: '/profiles/johndoe/follow',
+    headers: { Authorization: 'Bearer <token>' }
+  })
+  t.equal(response.statusCode, 403, 'returns a status code of 403 Forbidden')
+
+  await runSecurityTestBrokenAccessControl('DELETE', 'https://localhost:3000/profiles/johndoe/follow');
+
+  t.end()
+})
+
+teardownRunner();

--- a/test/routes/sentiment.test.js
+++ b/test/routes/sentiment.test.js
@@ -1,6 +1,7 @@
 'use strict'
 const t = require('tap');
-const { Configuration, SecRunner } = require('@sectester/runner');
+const { Configuration } = require('@sectester/core');
+const { SecRunner } = require('@sectester/runner');```
 const { TestType, Severity } = require('@sectester/scan');
 const startServer = require('../setup-server');
 

--- a/test/routes/sentiment.test.js
+++ b/test/routes/sentiment.test.js
@@ -1,0 +1,37 @@
+'use strict'
+const t = require('tap');
+const { Configuration, SecRunner } = require('@sectester/runner');
+const { TestType, Severity } = require('@sectester/scan');
+const startServer = require('../setup-server');
+
+const configuration = new Configuration({ hostname: 'app.brightsec.com' });
+
+const runSecurityTests = async () => {
+  const runner = new SecRunner(configuration);
+  await runner.init();
+
+  const scan = runner.createScan({
+    tests: [TestType.XSS, TestType.SQLI],
+    threshold: Severity.MEDIUM,
+    timeout: 300000, // 5 minutes
+  });
+
+  const server = await startServer();
+  const response = await server.inject({
+    method: 'POST',
+    url: '/sentiment/score',
+    headers: { 'Content-Type': 'application/json' },
+    payload: { content: 'string' },
+  });
+
+  await scan.run({
+    method: 'POST',
+    url: 'http://localhost:3000/sentiment/score',
+    body: { content: 'string' },
+  });
+
+  await runner.clear();
+  server.close();
+};
+
+runSecurityTests().catch((err) => console.error(err));

--- a/test/sec/articles.e2e-spec.ts
+++ b/test/sec/articles.e2e-spec.ts
@@ -1,0 +1,112 @@
+import { ArticlesModule } from '../../src/articles';
+import config from '../../src/mikro-orm.config';
+import { SecRunner } from '@sectester/runner';
+import { AttackParamLocation, Severity, TestType } from '@sectester/scan';
+import { INestApplication } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { ConfigModule } from '@nestjs/config';
+import { MikroOrmModule } from '@mikro-orm/nestjs';
+import { Server } from 'https';
+
+describe('/articles', () => {
+  const timeout = 600000;
+  jest.setTimeout(timeout);
+
+  let runner!: SecRunner;
+  let app!: INestApplication;
+  let baseUrl!: string;
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [
+        ArticlesModule,
+        ConfigModule.forRoot(),
+        MikroOrmModule.forRoot(config)
+      ]
+    }).compile();
+
+    app = moduleFixture.createNestApplication({
+      logger: false
+    });
+    await app.init();
+
+    const server = app.getHttpServer();
+
+    server.listen(0);
+
+    const port = server.address().port;
+    const protocol = server instanceof Server ? 'https' : 'http';
+    baseUrl = `${protocol}://localhost:${port}`;
+  });
+
+  afterAll(() => app.close());
+
+  beforeEach(async () => {
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    runner = new SecRunner({ hostname: process.env.BRIGHT_HOSTNAME! });
+
+    await runner.init();
+  });
+
+  afterEach(() => runner.clear());
+
+  describe('GET /', () => {
+    it('should not have SQLi', async () => {
+      await runner
+        .createScan({
+          name: expect.getState().currentTestName,
+          tests: [TestType.SQLI],
+          attackParamLocations: [AttackParamLocation.QUERY]
+        })
+        .threshold(Severity.MEDIUM)
+        .timeout(timeout)
+        .run({
+          method: 'GET',
+          url: `${baseUrl}/articles`,
+          query: {
+            tag: 'test',
+            author: 'test',
+            favorited: 'test',
+            limit: 10,
+            offset: 0
+          }
+        });
+    });
+  });
+
+  describe('GET /:slug', () => {
+    it('should not have SQLi', async () => {
+      await runner
+        .createScan({
+          name: expect.getState().currentTestName,
+          tests: [TestType.SQLI],
+          attackParamLocations: [AttackParamLocation.PATH]
+        })
+        .threshold(Severity.MEDIUM)
+        .timeout(timeout)
+        .run({
+          method: 'GET',
+          url: `${baseUrl}/articles/test-article`
+        });
+    });
+  });
+
+  describe('POST /articles/{slug}/favorite', () => {
+    it('should not have XSS', async () => {
+      await runner
+        .createScan({
+          name: expect.getState().currentTestName,
+          tests: [TestType.XSS],
+          attackParamLocations: [AttackParamLocation.BODY]
+        })
+        .threshold(Severity.MEDIUM)
+        .timeout(timeout)
+        .run({
+          method: 'POST',
+          url: `${baseUrl}/articles/test-article/favorite`,
+          headers: { Authorization: 'Token jwt.token.here' },
+          body: {}
+        });
+    });
+  });
+});

--- a/test/sec/tags.e2e-spec.ts
+++ b/test/sec/tags.e2e-spec.ts
@@ -1,0 +1,42 @@
+import { SecRunner } from '@sectester/runner';
+import { TestType } from '@sectester/scan';
+import { describe, it, beforeEach, afterEach } from 'mocha';
+import { expect } from 'chai';
+import startServer from '../setup-server';
+
+let runner: SecRunner;
+let server: any;
+
+beforeEach(async () => {
+  runner = new SecRunner({ hostname: 'app.brightsec.com' });
+  await runner.init();
+  server = await startServer();
+});
+
+afterEach(async () => {
+  await runner.clear();
+  server.close();
+});
+
+describe('GET /tags', () => {
+  it('should not have XSS vulnerabilities', async () => {
+    const scan = runner.createScan({
+      tests: [TestType.XSS],
+      threshold: 'MEDIUM',
+      timeout: 300000 // 5 minutes
+    });
+
+    const response = await server.inject({
+      method: 'GET',
+      url: '/api/tags'
+    });
+
+    await scan.run({
+      method: 'GET',
+      url: 'http://localhost:3000/api/tags'
+    });
+
+    expect(response.statusCode).to.equal(200);
+    expect(JSON.parse(response.body).tags.length).to.equal(0);
+  });
+});

--- a/test/sec/user.e2e-spec.ts
+++ b/test/sec/user.e2e-spec.ts
@@ -1,0 +1,94 @@
+import { SecRunner } from '@sectester/runner';
+import { AttackParamLocation, Severity, TestType } from '@sectester/scan';
+import { INestApplication } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { ConfigModule } from '@nestjs/config';
+import { Server } from 'https';
+
+const timeout = 600000;
+
+jest.setTimeout(timeout);
+
+let runner!: SecRunner;
+let app!: INestApplication;
+let baseUrl!: string;
+
+beforeAll(async () => {
+  const moduleFixture: TestingModule = await Test.createTestingModule({
+    imports: [
+      ConfigModule.forRoot()
+    ]
+  }).compile();
+
+  app = moduleFixture.createNestApplication({
+    logger: false
+  });
+  await app.init();
+
+  const server = app.getHttpServer();
+
+  server.listen(0);
+
+  const port = server.address().port;
+  const protocol = server instanceof Server ? 'https' : 'http';
+  baseUrl = `${protocol}://localhost:${port}`;
+});
+
+afterAll(() => app.close());
+
+beforeEach(async () => {
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+  runner = new SecRunner({ hostname: process.env.BRIGHT_HOSTNAME! });
+
+  await runner.init();
+});
+
+afterEach(() => runner.clear());
+
+describe('/user', () => {
+  describe('GET /api/user', () => {
+    it('should not have SQLi', async () => {
+      await runner
+        .createScan({
+          name: expect.getState().currentTestName,
+          tests: [TestType.SQLI],
+          attackParamLocations: [AttackParamLocation.QUERY]
+        })
+        .threshold(Severity.MEDIUM)
+        .timeout(timeout)
+        .run({
+          method: 'GET',
+          url: `${baseUrl}/api/user`,
+          headers: { Authorization: 'Bearer <token>' }
+        });
+    });
+  });
+
+  describe('PUT /user', () => {
+    it('should not have SQLi', async () => {
+      await runner
+        .createScan({
+          name: expect.getState().currentTestName,
+          tests: [TestType.SQLI],
+          attackParamLocations: [AttackParamLocation.BODY]
+        })
+        .threshold(Severity.MEDIUM)
+        .timeout(timeout)
+        .run({
+          method: 'PUT',
+          url: `${baseUrl}/user`,
+          headers: {
+            'Authorization': 'Bearer <token>',
+            'Content-Type': 'application/json'
+          },
+          body: {
+            user: {
+              username: 'updateduser',
+              email: 'updateduser@example.com',
+              password: 'newpassword123'
+            }
+          }
+        });
+    });
+  });
+});

--- a/test/sec/users-login.e2e-spec.ts
+++ b/test/sec/users-login.e2e-spec.ts
@@ -1,0 +1,98 @@
+import { SecRunner } from '@sectester/runner';
+import { AttackParamLocation, Severity, TestType } from '@sectester/scan';
+import { INestApplication } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { ConfigModule } from '@nestjs/config';
+import { Server } from 'https';
+
+const timeout = 600000;
+jest.setTimeout(timeout);
+
+let runner!: SecRunner;
+let app!: INestApplication;
+let baseUrl!: string;
+
+beforeAll(async () => {
+  const moduleFixture: TestingModule = await Test.createTestingModule({
+    imports: [
+      ConfigModule.forRoot()
+    ]
+  }).compile();
+
+  app = moduleFixture.createNestApplication({
+    logger: false
+  });
+  await app.init();
+
+  const server = app.getHttpServer();
+
+  server.listen(0);
+
+  const port = server.address().port;
+  const protocol = server instanceof Server ? 'https' : 'http';
+  baseUrl = `${protocol}://localhost:${port}`;
+});
+
+afterAll(() => app.close());
+
+beforeEach(async () => {
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+  runner = new SecRunner({ hostname: process.env.BRIGHT_HOSTNAME! });
+
+  await runner.init();
+});
+
+afterEach(() => runner.clear());
+
+describe('POST /api/users/login', () => {
+  it('should not have SQLi', async () => {
+    await runner
+      .createScan({
+        name: expect.getState().currentTestName,
+        tests: [TestType.SQLI],
+        attackParamLocations: [AttackParamLocation.BODY]
+      })
+      .threshold(Severity.MEDIUM)
+      .timeout(timeout)
+      .run({
+        method: 'POST',
+        url: `${baseUrl}/api/users/login`,
+        headers: { 'Content-Type': 'application/json' },
+        body: { user: { email: 'user@example.com', password: 'password123' } }
+      });
+  });
+
+  it('should not have XSS', async () => {
+    await runner
+      .createScan({
+        name: expect.getState().currentTestName,
+        tests: [TestType.XSS],
+        attackParamLocations: [AttackParamLocation.BODY]
+      })
+      .threshold(Severity.MEDIUM)
+      .timeout(timeout)
+      .run({
+        method: 'POST',
+        url: `${baseUrl}/api/users/login`,
+        headers: { 'Content-Type': 'application/json' },
+        body: { user: { email: 'user@example.com', password: 'password123' } }
+      });
+  });
+
+  it('should not have CSRF', async () => {
+    await runner
+      .createScan({
+        name: expect.getState().currentTestName,
+        tests: [TestType.CSRF],
+        attackParamLocations: [AttackParamLocation.BODY]
+      })
+      .threshold(Severity.MEDIUM)
+      .timeout(timeout)
+      .run({
+        method: 'POST',
+        url: `${baseUrl}/api/users/login`,
+        headers: { 'Content-Type': 'application/json' },
+        body: { user: { email: 'user@example.com', password: 'password123' } }
+      });
+  });
+});

--- a/test/sec/users.e2e-spec.ts
+++ b/test/sec/users.e2e-spec.ts
@@ -1,0 +1,106 @@
+import { UsersModule } from '../../src/users';
+import config from '../../src/mikro-orm.config';
+import { SecRunner } from '@sectester/runner';
+import { AttackParamLocation, Severity, TestType } from '@sectester/scan';
+import { INestApplication } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { ConfigModule } from '@nestjs/config';
+import { MikroOrmModule } from '@mikro-orm/nestjs';
+import { Server } from 'https';
+
+describe('/users', () => {
+  const timeout = 600000;
+  jest.setTimeout(timeout);
+
+  let runner!: SecRunner;
+  let app!: INestApplication;
+  let baseUrl!: string;
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [
+        UsersModule,
+        ConfigModule.forRoot(),
+        MikroOrmModule.forRoot(config)
+      ]
+    }).compile();
+
+    app = moduleFixture.createNestApplication({
+      logger: false
+    });
+    await app.init();
+
+    const server = app.getHttpServer();
+
+    server.listen(0);
+
+    const port = server.address().port;
+    const protocol = server instanceof Server ? 'https' : 'http';
+    baseUrl = `${protocol}://localhost:${port}`;
+  });
+
+  afterAll(() => app.close());
+
+  beforeEach(async () => {
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    runner = new SecRunner({ hostname: process.env.BRIGHT_HOSTNAME! });
+
+    await runner.init();
+  });
+
+  afterEach(() => runner.clear());
+
+  describe('POST /', () => {
+    it('should not have XSS', async () => {
+      await runner
+        .createScan({
+          name: expect.getState().currentTestName,
+          tests: [TestType.XSS],
+          attackParamLocations: [AttackParamLocation.BODY]
+        })
+        .threshold(Severity.MEDIUM)
+        .timeout(timeout)
+        .run({
+          method: 'POST',
+          url: `${baseUrl}/users`,
+          body: { firstName: 'Test', lastName: 'Test' }
+        });
+    });
+  });
+
+  describe('GET /:id', () => {
+    it('should not have SQLi', async () => {
+      await runner
+        .createScan({
+          name: expect.getState().currentTestName,
+          tests: [TestType.SQLI],
+          attackParamLocations: [AttackParamLocation.PATH]
+        })
+        .threshold(Severity.MEDIUM)
+        .timeout(timeout)
+        .run({
+          method: 'GET',
+          url: `${baseUrl}/users/1`
+        });
+    });
+  });
+
+  describe('POST /api/users', () => {
+    it('should not have SQLi or XSS', async () => {
+      await runner
+        .createScan({
+          name: expect.getState().currentTestName,
+          tests: [TestType.SQLI, TestType.XSS],
+          attackParamLocations: [AttackParamLocation.BODY]
+        })
+        .threshold(Severity.MEDIUM)
+        .timeout(timeout)
+        .run({
+          method: 'POST',
+          url: `${baseUrl}/api/users`,
+          headers: { 'Content-Type': 'application/json' },
+          body: { user: { username: 'newuser', email: 'newuser@example.com', password: 'password123' } }
+        });
+    });
+  });
+});


### PR DESCRIPTION
## Description

This PR adds security tests using Bright's SecTester SDK to ensure the robustness of our API endpoints. The tests cover various security vulnerabilities including SQL injection, XSS, and authentication bypass.

## Test Plan

- Ensure the Bright API key is set in the environment variables.
- Run the security tests using the provided test scripts.
- Validate that the tests pass without any vulnerabilities detected.

## Endpoints Tested

- GET /articles
- GET /articles/feed
- GET /articles/{slug}
- POST /articles
- PUT /articles/{slug}
- DELETE /articles/{slug}
- POST /articles/{slug}/favorite
- DELETE /articles/{slug}/favorite
- GET /articles/example-article/comments
- POST /articles/example-article/comments
- DELETE /articles/example-article/comments/1
- GET /profiles/johndoe
- POST /profiles/johndoe/follow
- DELETE /profiles/johndoe/follow
- POST /sentiment/score
- GET http://example.com/tags
- POST http://localhost:3000/api/users/login
- POST http://localhost:3000/api/users
- GET http://localhost:3000/api/user
- PUT http://localhost:3000/api/user

## Checklist
- [x] Tests implemented
- [x] Documentation updated