### PR TITLE
test: add API security tests using Bright

### DIFF
--- a/.github/workflows/bright.yml
+++ b/.github/workflows/bright.yml
@@ -1,0 +1,30 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - '**'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    env:
+      BRIGHT_HOSTNAME: ${{ vars.BRIGHT_HOSTNAME }}
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
+    - name: Set up Node.js
+      uses: actions/setup-node@v2
+      with:
+        node-version: '14'
+
+    - name: Install dependencies
+      run: npm ci
+
+    - name: Run tests
+      run: npm test -- test/sec/**/*
+      env:
+        BRIGHT_TOKEN: ${{ secrets.BRIGHT_TOKEN }}

--- a/test/routes/sentiment.test.js
+++ b/test/routes/sentiment.test.js
@@ -1,0 +1,29 @@
+import { SecRunner, SecScan } from '@sectester/runner';
+import { Severity, TestType } from '@sectester/scan';
+
+describe('/sentiment/score', () => {
+  let runner;
+  let scan;
+
+  beforeEach(async () => {
+    runner = new SecRunner({ hostname: 'app.neuralegion.com' });
+    await runner.init();
+    scan = runner
+      .createScan({ tests: [TestType.CSRF, TestType.XSS, TestType.SQLI, 'excessive_data_exposure', 'insecure_output_handling'] })
+      .threshold(Severity.MEDIUM)
+      .timeout(300000); // 5 minutes
+  });
+
+  afterEach(async () => {
+    await runner.clear();
+  });
+
+  it('should pass security tests', async () => {
+    await scan.run({
+      method: 'POST',
+      url: 'https://localhost:8000/sentiment/score',
+      headers: { 'Content-Type': 'application/json' },
+      body: { content: 'string' }
+    });
+  });
+});

--- a/test/sec/articles.e2e-spec.ts
+++ b/test/sec/articles.e2e-spec.ts
@@ -1,0 +1,247 @@
+import { SecRunner } from '@sectester/runner';
+import { AttackParamLocation, Severity, TestType } from '@sectester/scan';
+
+const timeout = 300000;
+
+let runner!: SecRunner;
+let baseUrl!: string;
+
+beforeAll(async () => {
+  runner = new SecRunner({ hostname: 'app.neuralegion.com' });
+  await runner.init();
+  baseUrl = 'http://localhost:3000';
+});
+
+afterAll(() => runner.clear());
+
+jest.setTimeout(timeout);
+
+describe('/api/articles', () => {
+  it('GET / should not have excessive data exposure, sqli, xss, csrf, http method fuzzing, or mass assignment vulnerabilities', async () => {
+    await runner
+      .createScan({
+        tests: [
+          'excessive_data_exposure',
+          TestType.SQLI,
+          TestType.XSS,
+          TestType.CSRF,
+          TestType.HTTP_METHOD_FUZZING,
+          TestType.MASS_ASSIGNMENT
+        ],
+        attackParamLocations: [
+          AttackParamLocation.QUERY,
+          AttackParamLocation.BODY
+        ]
+      })
+      .threshold(Severity.MEDIUM)
+      .timeout(timeout)
+      .run({
+        method: 'GET',
+        url: 'http://localhost:3000/api/articles',
+        query: {
+          tag: 'string',
+          author: 'string',
+          favorited: 'string',
+          limit: 'number',
+          offset: 'number'
+        }
+      });
+  });
+
+  it('GET /slug-example should not have broken access control, excessive data exposure, or id enumeration vulnerabilities', async () => {
+    await runner
+      .createScan({
+        tests: ['broken_access_control', 'excessive_data_exposure', TestType.ID_ENUMERATION],
+        attackParamLocations: [AttackParamLocation.PATH]
+      })
+      .threshold(Severity.MEDIUM)
+      .timeout(timeout)
+      .run({
+        method: 'GET',
+        url: `${baseUrl}/api/articles/slug-example`
+      });
+  });
+
+  it('POST /api/articles should not have vulnerabilities', async () => {
+    await runner
+      .createScan({
+        tests: [TestType.JWT, TestType.CSRF, TestType.MASS_ASSIGNMENT, TestType.XSS, TestType.SQLI],
+        attackParamLocations: [AttackParamLocation.BODY, AttackParamLocation.HEADER]
+      })
+      .threshold(Severity.MEDIUM)
+      .timeout(timeout)
+      .run({
+        method: 'POST',
+        url: `${baseUrl}/api/articles`,
+        headers: {
+          'Authorization': 'Token jwt.token.here',
+          'Content-Type': 'application/json'
+        },
+        body: {
+          article: {
+            title: 'string',
+            description: 'string',
+            body: 'string',
+            tagList: ['string']
+          }
+        }
+      });
+  });
+
+  describe('PUT /articles/slug-example', () => {
+    it('should not have vulnerabilities', async () => {
+      await runner
+        .createScan({
+          tests: [TestType.JWT, TestType.CSRF, TestType.MASS_ASSIGNMENT, TestType.XSS, TestType.SQLI],
+          attackParamLocations: [AttackParamLocation.BODY, AttackParamLocation.HEADER]
+        })
+        .threshold(Severity.MEDIUM)
+        .timeout(timeout)
+        .run({
+          method: 'PUT',
+          url: `${baseUrl}/api/articles/slug-example`,
+          headers: {
+            Authorization: 'Token jwt.token.here',
+            'Content-Type': 'application/json'
+          },
+          body: {
+            article: {
+              title: 'string',
+              description: 'string',
+              body: 'string'
+            }
+          }
+        });
+    });
+  });
+
+  describe('DELETE /articles/slug-example', () => {
+    it('should not have broken access control, jwt, csrf, or http method fuzzing vulnerabilities', async () => {
+      await runner
+        .createScan({
+          tests: [
+            'broken_access_control',
+            TestType.JWT,
+            TestType.CSRF,
+            TestType.HTTP_METHOD_FUZZING
+          ],
+          attackParamLocations: [AttackParamLocation.HEADER]
+        })
+        .threshold(Severity.MEDIUM)
+        .timeout(timeout)
+        .run({
+          method: 'DELETE',
+          url: 'http://localhost:3000/api/articles/slug-example',
+          headers: {
+            Authorization: 'Token jwt.token.here'
+          }
+        });
+    });
+  });
+
+  describe('DELETE /articles/slug-example/favorite', () => {
+    it('should pass security tests', async () => {
+      await runner
+        .createScan({
+          tests: [TestType.JWT, TestType.BROKEN_ACCESS_CONTROL, TestType.CSRF, TestType.HTTP_METHOD_FUZZING],
+          attackParamLocations: [AttackParamLocation.HEADER, AttackParamLocation.PATH]
+        })
+        .threshold(Severity.MEDIUM)
+        .timeout(timeout)
+        .run({
+          method: 'DELETE',
+          url: `${baseUrl}/api/articles/slug-example/favorite`,
+          headers: { Authorization: 'Token jwt.token.here' }
+        });
+    });
+  });
+});
+
+describe('/api/articles/feed', () => {
+  it('should not have security issues', async () => {
+    await runner
+      .createScan({
+        tests: [TestType.JWT, 'excessive_data_exposure', 'broken_access_control', TestType.CSRF, TestType.HTTP_METHOD_FUZZING],
+        attackParamLocations: [AttackParamLocation.QUERY, AttackParamLocation.HEADER]
+      })
+      .threshold(Severity.MEDIUM)
+      .timeout(timeout)
+      .run({
+        method: 'GET',
+        url: `${baseUrl}/api/articles/feed`,
+        headers: { Authorization: 'Token jwt.token.here' },
+        query: { limit: 'number', offset: 'number' }
+      });
+  });
+});
+
+describe('/api/articles/slug-example/favorite', () => {
+  it('POST / should pass security tests', async () => {
+    await runner
+      .createScan({
+        tests: [TestType.JWT, TestType.CSRF, TestType.BROKEN_ACCESS_CONTROL, TestType.HTTP_METHOD_FUZZING, TestType.XSS],
+        attackParamLocations: [AttackParamLocation.HEADER, AttackParamLocation.BODY]
+      })
+      .threshold(Severity.MEDIUM)
+      .timeout(timeout)
+      .run({
+        method: 'POST',
+        url: `${baseUrl}/api/articles/slug-example/favorite`,
+        headers: { Authorization: 'Token jwt.token.here' },
+        body: {}
+      });
+  });
+});
+
+describe('/api/articles/sample-article/comments', () => {
+  it('GET / should not have broken access control, csrf, excessive data exposure, or xss vulnerabilities', async () => {
+    await runner
+      .createScan({
+        tests: [TestType.BROKEN_ACCESS_CONTROL, TestType.CSRF, TestType.EXCESSIVE_DATA_EXPOSURE, TestType.XSS],
+        attackParamLocations: [AttackParamLocation.HEADER, AttackParamLocation.QUERY, AttackParamLocation.BODY]
+      })
+      .threshold(Severity.MEDIUM)
+      .timeout(timeout)
+      .run({
+        method: 'GET',
+        url: 'http://example.com/api/articles/sample-article/comments',
+        headers: { Authorization: 'Bearer <optional_token>' }
+      });
+  });
+
+  it('POST / should not have CSRF, XSS, SQLi, Broken Access Control, or Excessive Data Exposure', async () => {
+    await runner
+      .createScan({
+        tests: [TestType.CSRF, TestType.XSS, TestType.SQLI, 'broken_access_control', 'excessive_data_exposure'],
+        attackParamLocations: [AttackParamLocation.BODY, AttackParamLocation.HEADER]
+      })
+      .threshold(Severity.MEDIUM)
+      .timeout(timeout)
+      .run({
+        method: 'POST',
+        url: 'http://example.com/api/articles/sample-article/comments',
+        headers: {
+          Authorization: 'Bearer <token>',
+          'Content-Type': 'application/json'
+        },
+        body: { comment: { body: 'This is a comment.' } }
+      });
+  });
+});
+
+describe('/api/articles/sample-article/comments/:id', () => {
+  it('DELETE /:id should not have broken access control, CSRF, or ID enumeration vulnerabilities', async () => {
+    await runner
+      .createScan({
+        tests: [TestType.BROKEN_ACCESS_CONTROL, TestType.CSRF, TestType.ID_ENUMERATION],
+        attackParamLocations: [AttackParamLocation.PATH]
+      })
+      .threshold(Severity.MEDIUM)
+      .timeout(timeout)
+      .run({
+        method: 'DELETE',
+        url: 'http://example.com/api/articles/sample-article/comments/123',
+        headers: { Authorization: 'Bearer <token>' }
+      });
+  });
+});

--- a/test/sec/profiles.e2e-spec.ts
+++ b/test/sec/profiles.e2e-spec.ts
@@ -1,0 +1,51 @@
+import { SecRunner } from '@sectester/runner';
+import { TestType, Severity, AttackParamLocation } from '@sectester/scan';
+
+describe('/profiles', () => {
+  const timeout = 300000;
+  jest.setTimeout(timeout);
+
+  let runner!: SecRunner;
+  let baseUrl!: string;
+
+  beforeAll(async () => {
+    runner = new SecRunner({ hostname: 'app.neuralegion.com' });
+    await runner.init();
+    baseUrl = 'https://localhost:8000';
+  });
+
+  afterAll(() => runner.clear());
+
+  it('GET /profiles/johndoe', async () => {
+    await runner
+      .createScan({
+        tests: [TestType.BROKEN_ACCESS_CONTROL, TestType.JWT, TestType.EXCESSIVE_DATA_EXPOSURE],
+        attackParamLocations: [AttackParamLocation.PATH]
+      })
+      .threshold(Severity.MEDIUM)
+      .timeout(timeout)
+      .run({
+        method: 'GET',
+        url: `${baseUrl}/profiles/johndoe`,
+        headers: { Authorization: 'Token optional_jwt_token' }
+      });
+  });
+
+  describe('/johndoe/follow', () => {
+    it('should not have jwt, csrf, broken_access_control, xss vulnerabilities', async () => {
+      await runner
+        .createScan({
+          tests: [TestType.JWT, TestType.CSRF, 'broken_access_control', TestType.XSS],
+          attackParamLocations: [AttackParamLocation.BODY, AttackParamLocation.HEADER]
+        })
+        .threshold(Severity.MEDIUM)
+        .timeout(timeout)
+        .run({
+          method: 'POST',
+          url: `${baseUrl}/profiles/johndoe/follow`,
+          headers: { Authorization: 'Token required_jwt_token' },
+          body: {}
+        });
+    });
+  });
+});

--- a/test/sec/tags.e2e-spec.ts
+++ b/test/sec/tags.e2e-spec.ts
@@ -1,0 +1,29 @@
+import { SecRunner } from '@sectester/runner';
+import { TestType } from '@sectester/scan';
+
+describe('/tags', () => {
+  let runner!: SecRunner;
+  const timeout = 300000;
+
+  beforeAll(async () => {
+    runner = new SecRunner({ hostname: 'app.neuralegion.com' });
+    await runner.init();
+  });
+
+  afterAll(async () => {
+    await runner.clear();
+  });
+
+  it('should not have excessive data exposure or insecure HTTP methods', async () => {
+    await runner
+      .createScan({
+        tests: ['excessive_data_exposure', TestType.HTTP_METHOD_FUZZING]
+      })
+      .threshold(Severity.MEDIUM)
+      .timeout(timeout)
+      .run({
+        method: 'GET',
+        url: 'http://localhost:3000/tags'
+      });
+  });
+});

--- a/test/sec/user.e2e-spec.ts
+++ b/test/sec/user.e2e-spec.ts
@@ -1,0 +1,67 @@
+import { SecRunner } from '@sectester/runner';
+import { TestType, AttackParamLocation, Severity } from '@sectester/scan';
+
+describe('/api/user', () => {
+  const timeout = 300000;
+  jest.setTimeout(timeout);
+
+  let runner!: SecRunner;
+  let baseUrl!: string;
+
+  beforeAll(async () => {
+    runner = new SecRunner({ hostname: 'app.neuralegion.com' });
+    await runner.init();
+    baseUrl = 'https://localhost:8000';
+  });
+
+  afterAll(() => runner.clear());
+
+  it('GET /api/user should not have broken access control, jwt issues, or excessive data exposure', async () => {
+    await runner
+      .createScan({
+        tests: ['broken_access_control', TestType.JWT, 'excessive_data_exposure'],
+        attackParamLocations: [AttackParamLocation.HEADER, AttackParamLocation.QUERY, AttackParamLocation.BODY]
+      })
+      .threshold(Severity.MEDIUM)
+      .timeout(timeout)
+      .run({
+        method: 'GET',
+        url: `${baseUrl}/api/user`,
+        headers: { Authorization: 'Bearer <token>' }
+      });
+  });
+
+  it('PUT /api/user should not have vulnerabilities', async () => {
+    await runner
+      .createScan({
+        tests: [
+          TestType.JWT,
+          TestType.BRUTE_FORCE_LOGIN,
+          TestType.CSRF,
+          TestType.MASS_ASSIGNMENT,
+          TestType.SQLI,
+          TestType.XSS
+        ],
+        attackParamLocations: [
+          AttackParamLocation.BODY,
+          AttackParamLocation.HEADER
+        ]
+      })
+      .threshold(Severity.MEDIUM)
+      .timeout(timeout)
+      .run({
+        method: 'PUT',
+        url: `${baseUrl}/api/user`,
+        headers: {
+          Authorization: 'Bearer <token>',
+          'Content-Type': 'application/json'
+        },
+        body: {
+          user: {
+            email: 'updated@example.com',
+            password: 'newpassword123'
+          }
+        }
+      });
+  });
+});

--- a/test/sec/users.e2e-spec.ts
+++ b/test/sec/users.e2e-spec.ts
@@ -1,0 +1,64 @@
+import { SecRunner } from '@sectester/runner';
+import { AttackParamLocation, Severity, TestType } from '@sectester/scan';
+
+describe('/api/users', () => {
+  const timeout = 300000;
+  jest.setTimeout(timeout);
+
+  let runner!: SecRunner;
+
+  beforeAll(async () => {
+    runner = new SecRunner({ hostname: 'app.neuralegion.com' });
+    await runner.init();
+  });
+
+  afterAll(() => runner.clear());
+
+  describe('POST /api/users/login', () => {
+    it('should not have vulnerabilities', async () => {
+      await runner
+        .createScan({
+          tests: [
+            TestType.BRUTE_FORCE_LOGIN,
+            TestType.CSRF,
+            TestType.SQLI,
+            TestType.XSS,
+            'insecure_output_handling'
+          ],
+          attackParamLocations: [AttackParamLocation.BODY]
+        })
+        .threshold(Severity.MEDIUM)
+        .timeout(timeout)
+        .run({
+          method: 'POST',
+          url: 'https://localhost:8000/api/users/login',
+          headers: { 'Content-Type': 'application/json' },
+          body: { user: { email: 'example@example.com', password: 'password123' } }
+        });
+    });
+  });
+
+  describe('POST /api/users', () => {
+    it('should not have vulnerabilities', async () => {
+      await runner
+        .createScan({
+          tests: [
+            TestType.BRUTE_FORCE_LOGIN,
+            TestType.CSRF,
+            TestType.MASS_ASSIGNMENT,
+            TestType.SQLI,
+            TestType.XSS
+          ],
+          attackParamLocations: [AttackParamLocation.BODY]
+        })
+        .threshold(Severity.MEDIUM)
+        .timeout(timeout)
+        .run({
+          method: 'POST',
+          url: 'https://localhost:8000/api/users',
+          headers: { 'Content-Type': 'application/json' },
+          body: { user: { username: 'newuser', email: 'newuser@example.com', password: 'password123' } }
+        });
+    });
+  });
+});

--- a/test/security/profiles.test.js
+++ b/test/security/profiles.test.js
@@ -1,0 +1,33 @@
+import { SecRunner, SecScan } from '@sectester/runner';
+import { Severity, TestType } from '@sectester/scan';
+
+describe('/profiles', () => {
+  let runner;
+  let scan;
+  const timeout = 300000;
+  const baseUrl = 'http://localhost:3000';
+
+  beforeAll(async () => {
+    runner = new SecRunner({ hostname: 'app.neuralegion.com' });
+    await runner.init();
+  });
+
+  afterAll(async () => {
+    await runner.clear();
+  });
+
+  describe('/johndoe/follow', () => {
+    it('should not have security issues', async () => {
+      scan = runner.createScan({
+        tests: [TestType.JWT, 'broken_access_control', TestType.CSRF, TestType.HTTP_METHOD_FUZZING],
+        attackParamLocations: ['header', 'body', 'query']
+      }).threshold(Severity.MEDIUM).timeout(timeout);
+
+      await scan.run({
+        method: 'DELETE',
+        url: `${baseUrl}/profiles/johndoe/follow`,
+        headers: { 'Authorization': 'Token required_jwt_token' }
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Description

- Added security tests using Bright's SecTester for various API endpoints.

## Test Plan

- Ensure the Bright API key is set in the environment variables.
- Run the security tests using the provided test scripts.
- Validate that the tests cover the specified endpoints and check for vulnerabilities.

## Endpoints Tested

- GET http://localhost:3000/api/articles
- GET http://localhost:3000/api/articles/feed
- GET http://localhost:3000/api/articles/slug-example
- POST http://localhost:3000/api/articles
- PUT http://localhost:3000/api/articles/slug-example
- DELETE http://localhost:3000/api/articles/slug-example
- POST http://localhost:3000/api/articles/slug-example/favorite
- DELETE http://localhost:3000/api/articles/slug-example/favorite
- GET http://example.com/api/articles/sample-article/comments
- POST http://example.com/api/articles/sample-article/comments
- DELETE http://example.com/api/articles/sample-article/comments/123
- GET /profiles/johndoe
- POST /profiles/johndoe/follow
- DELETE /profiles/johndoe/follow
- POST /sentiment/score
- GET http://localhost:3000/tags
- POST /api/users/login
- POST /api/users
- GET /api/user
- PUT /api/user

## Types of Security Checks

- SQL Injection
- XSS Vulnerabilities
- Authentication Bypass

## Checklist
- [x] Tests implemented
- [x] Documentation updated