### PR TITLE
test(security): add security tests for article and profile endpoints

### DIFF
--- a/.github/workflows/bright.yml
+++ b/.github/workflows/bright.yml
@@ -1,0 +1,29 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - '**'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    env:
+      BRIGHT_HOSTNAME: ${{ vars.BRIGHT_HOSTNAME }}
+      BRIGHT_TOKEN: ${{ secrets.BRIGHT_TOKEN }}
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
+    - name: Set up Node.js
+      uses: actions/setup-node@v2
+      with:
+        node-version: '14'
+
+    - name: Install dependencies
+      run: npm install
+
+    - name: Run tests
+      run: npm test -- test/sec/*

--- a/test/sec/delete-api-profiles-username-follow.test.js
+++ b/test/sec/delete-api-profiles-username-follow.test.js
@@ -1,0 +1,55 @@
+'use strict'
+const t = require('tap')
+const startServer = require('../setup-server')
+const { SecRunner, TestType, AttackParamLocation, Severity } = require('@sectester/runner')
+
+let runner
+
+// Increase the timeout for the tests
+const testTimeout = 15 * 60 * 1000 // 15 minutes
+
+// Set the timeout for the tests
+jest.setTimeout(testTimeout)
+
+t.test('SecTester integration for DELETE /api/profiles/:username/follow', async t => {
+  let server
+  let baseUrl
+
+  t.before(async () => {
+    server = await startServer()
+    const address = server.server.address()
+    baseUrl = `http://localhost:${address.port}`
+  })
+
+  t.teardown(() => server.close())
+
+  t.beforeEach(async () => {
+    runner = new SecRunner({
+      hostname: process.env.BRIGHT_HOSTNAME
+    })
+    await runner.init()
+  })
+
+  t.afterEach(() => runner.clear())
+
+  t.test('Security tests for DELETE /api/profiles/:username/follow', async t => {
+    await runner
+      .createScan({
+        tests: [TestType.JWT, TestType.BROKEN_ACCESS_CONTROL, 'CSRF', TestType.HTTP_METHOD_FUZZING],
+        attackParamLocations: [AttackParamLocation.HEADER, AttackParamLocation.BODY, AttackParamLocation.PATH]
+      })
+      .threshold(Severity.MEDIUM)
+      .timeout(testTimeout)
+      .run({
+        method: 'DELETE',
+        url: `${baseUrl}/api/profiles/johndoe/follow`,
+        headers: {
+          Authorization: 'Token required_jwt_token'
+        }
+      })
+
+    t.end()
+  })
+
+  t.end()
+})

--- a/test/sec/delete-articles-example-article-comments-1.test.js
+++ b/test/sec/delete-articles-example-article-comments-1.test.js
@@ -1,0 +1,55 @@
+'use strict'
+const t = require('tap')
+const startServer = require('../setup-server')
+const { SecRunner, TestType, AttackParamLocation, Severity } = require('@sectester/runner')
+
+let runner
+
+// Increase the timeout for the tests
+const testTimeout = 15 * 60 * 1000 // 15 minutes
+
+// Set the timeout for the tests
+jest.setTimeout(testTimeout)
+
+t.test('DELETE /articles/example-article/comments/1', async t => {
+  let server
+  let baseUrl
+
+  t.before(async () => {
+    server = await startServer()
+    const address = server.server.address()
+    baseUrl = `http://localhost:${address.port}`
+  })
+
+  t.teardown(() => server.close())
+
+  t.beforeEach(async () => {
+    runner = new SecRunner({
+      hostname: process.env.BRIGHT_HOSTNAME
+    })
+    await runner.init()
+  })
+
+  t.afterEach(() => runner.clear())
+
+  t.test('Security tests', async t => {
+    await runner
+      .createScan({
+        tests: [TestType.BROKEN_ACCESS_CONTROL, TestType.JWT, 'id_enumeration'],
+        attackParamLocations: [AttackParamLocation.PATH]
+      })
+      .threshold(Severity.MEDIUM)
+      .timeout(testTimeout)
+      .run({
+        method: 'DELETE',
+        url: `${baseUrl}/articles/example-article/comments/1`,
+        headers: {
+          Authorization: 'Bearer <token>'
+        }
+      })
+
+    t.end()
+  })
+
+  t.end()
+})

--- a/test/sec/delete-articles-slug-favorite.test.js
+++ b/test/sec/delete-articles-slug-favorite.test.js
@@ -1,0 +1,52 @@
+'use strict'
+const t = require('tap')
+const startServer = require('../setup-server')
+const { SecRunner, TestType, AttackParamLocation, Severity } = require('@sectester/runner')
+
+let runner
+
+// Increase the timeout for the tests
+const testTimeout = 15 * 60 * 1000 // 15 minutes
+
+// Set the timeout for the tests
+jest.setTimeout(testTimeout)
+
+t.test('DELETE /articles/{slug}/favorite', async t => {
+  let server
+  let baseUrl
+
+  t.before(async () => {
+    server = await startServer()
+    const address = server.server.address()
+    baseUrl = `http://localhost:${address.port}`
+  })
+
+  t.teardown(() => server.close())
+
+  t.beforeEach(async () => {
+    runner = new SecRunner({
+      hostname: process.env.BRIGHT_HOSTNAME
+    })
+    await runner.init()
+  })
+
+  t.afterEach(() => runner.clear())
+
+  t.test('security tests', async t => {
+    await runner.createScan({
+      tests: [TestType.JWT, TestType.BROKEN_ACCESS_CONTROL, 'csrf', TestType.HTTP_METHOD_FUZZING],
+      attackParamLocations: [AttackParamLocation.HEADER, AttackParamLocation.PATH]
+    })
+    .threshold(Severity.MEDIUM)
+    .timeout(testTimeout)
+    .run({
+      method: 'DELETE',
+      url: `${baseUrl}/articles/{slug}/favorite`,
+      headers: { 'Authorization': 'Token jwt.token.here' }
+    })
+
+    t.end()
+  })
+
+  t.end()
+})

--- a/test/sec/delete-articles-slug.test.js
+++ b/test/sec/delete-articles-slug.test.js
@@ -1,0 +1,60 @@
+'use strict'
+const t = require('tap')
+const startServer = require('../setup-server')
+const { SecRunner, TestType, AttackParamLocation, Severity } = require('@sectester/runner')
+
+let runner
+
+// Increase the timeout for the tests
+const testTimeout = 15 * 60 * 1000 // 15 minutes
+
+// Set the timeout for the tests
+jest.setTimeout(testTimeout)
+
+t.test('DELETE /articles/{slug}', async t => {
+  let server
+  let baseUrl
+
+  t.before(async () => {
+    server = await startServer()
+    const address = server.server.address()
+    baseUrl = `http://localhost:${address.port}`
+  })
+
+  t.teardown(() => server.close())
+
+  t.beforeEach(async () => {
+    runner = new SecRunner({
+      hostname: process.env.BRIGHT_HOSTNAME
+    })
+    await runner.init()
+  })
+
+  t.afterEach(() => runner.clear())
+
+  t.test('Security tests for DELETE /articles/{slug}', async t => {
+    await runner.createScan({
+      tests: [
+        TestType.BROKEN_ACCESS_CONTROL,
+        TestType.JWT,
+        'csrf',
+        TestType.HTTP_METHOD_FUZZING,
+        TestType.SQLI
+      ],
+      attackParamLocations: [AttackParamLocation.PATH]
+    })
+    .threshold(Severity.MEDIUM)
+    .timeout(testTimeout)
+    .run({
+      method: 'DELETE',
+      url: `${baseUrl}/articles/test-slug`,
+      headers: {
+        Authorization: 'Token jwt.token.here'
+      }
+    })
+
+    t.end()
+  })
+
+  t.end()
+})

--- a/test/sec/get-api-user.test.js
+++ b/test/sec/get-api-user.test.js
@@ -1,0 +1,54 @@
+'use strict'
+const t = require('tap')
+const startServer = require('../setup-server')
+const { SecRunner, TestType, AttackParamLocation, Severity } = require('@sectester/runner')
+
+let runner
+
+// Increase the timeout for the tests
+const testTimeout = 15 * 60 * 1000 // 15 minutes
+
+// Set the timeout for the tests
+jest.setTimeout(testTimeout)
+
+t.test('SecTester integration for GET /api/user', async t => {
+  let server
+  let baseUrl
+
+  t.before(async () => {
+    server = await startServer()
+    const address = server.server.address()
+    baseUrl = `http://localhost:${address.port}`
+  })
+
+  t.teardown(() => server.close())
+
+  t.beforeEach(async () => {
+    runner = new SecRunner({
+      hostname: process.env.BRIGHT_HOSTNAME
+    })
+    await runner.init()
+  })
+
+  t.afterEach(() => runner.clear())
+
+  // Placeholder for actual test cases
+  t.test('Security tests for GET /api/user', async t => {
+    await runner
+      .createScan({
+        tests: [TestType.BROKEN_ACCESS_CONTROL, TestType.JWT, 'EXCESSIVE_DATA_EXPOSURE', TestType.HTTP_METHOD_FUZZING],
+        attackParamLocations: [AttackParamLocation.HEADER, AttackParamLocation.QUERY]
+      })
+      .threshold(Severity.MEDIUM)
+      .timeout(testTimeout)
+      .run({
+        method: 'GET',
+        url: `${baseUrl}/api/user`,
+        headers: { 'Authorization': 'Bearer <token>' }
+      })
+
+    t.end()
+  })
+
+  t.end()
+})

--- a/test/sec/get-articles-example-article-comments.test.js
+++ b/test/sec/get-articles-example-article-comments.test.js
@@ -1,0 +1,53 @@
+'use strict'
+const t = require('tap')
+const startServer = require('../setup-server')
+const { SecRunner, TestType, AttackParamLocation, Severity } = require('@sectester/runner')
+
+let runner
+
+// Increase the timeout for the tests
+const testTimeout = 15 * 60 * 1000 // 15 minutes
+
+// Set the timeout for the tests
+jest.setTimeout(testTimeout)
+
+t.test('GET /articles/example-article/comments', async t => {
+  let server
+  let baseUrl
+
+  t.before(async () => {
+    server = await startServer()
+    const address = server.server.address()
+    baseUrl = `http://localhost:${address.port}`
+  })
+
+  t.teardown(() => server.close())
+
+  t.beforeEach(async () => {
+    runner = new SecRunner({
+      hostname: process.env.BRIGHT_HOSTNAME
+    })
+    await runner.init()
+  })
+
+  t.afterEach(() => runner.clear())
+
+  t.test('Security tests for GET /articles/example-article/comments', async t => {
+    await runner.createScan({
+      tests: [TestType.BROKEN_ACCESS_CONTROL, TestType.JWT, 'EXCESSIVE_DATA_EXPOSURE'],
+      attackParamLocations: [AttackParamLocation.HEADER, AttackParamLocation.QUERY]
+    })
+    .threshold(Severity.MEDIUM)
+    .timeout(testTimeout)
+    .run({
+      method: 'GET',
+      url: `${baseUrl}/articles/example-article/comments`,
+      headers: {
+        'Authorization': 'Bearer <token>'
+      }
+    })
+    t.end()
+  })
+
+  t.end()
+})

--- a/test/sec/get-articles-feed.test.js
+++ b/test/sec/get-articles-feed.test.js
@@ -1,0 +1,53 @@
+'use strict'
+const t = require('tap')
+const startServer = require('../setup-server')
+const { SecRunner, TestType, AttackParamLocation, Severity } = require('@sectester/runner')
+
+let runner
+
+// Increase the timeout for the tests
+const testTimeout = 15 * 60 * 1000 // 15 minutes
+
+// Set the timeout for the tests
+jest.setTimeout(testTimeout)
+
+t.test('GET /articles/feed', async t => {
+  let server
+  let baseUrl
+
+  t.before(async () => {
+    server = await startServer()
+    const address = server.server.address()
+    baseUrl = `http://localhost:${address.port}`
+  })
+
+  t.teardown(() => server.close())
+
+  t.beforeEach(async () => {
+    runner = new SecRunner({
+      hostname: process.env.BRIGHT_HOSTNAME
+    })
+    await runner.init()
+  })
+
+  t.afterEach(() => runner.clear())
+
+  t.test('Security tests for GET /articles/feed', async t => {
+    await runner
+      .createScan({
+        tests: [TestType.JWT, TestType.BROKEN_ACCESS_CONTROL, TestType.EXCESSIVE_DATA_EXPOSURE, 'HTTP_METHOD_FUZZING'],
+        attackParamLocations: [AttackParamLocation.HEADER, AttackParamLocation.QUERY]
+      })
+      .threshold(Severity.MEDIUM)
+      .timeout(testTimeout)
+      .run({
+        method: 'GET',
+        url: `${baseUrl}/articles/feed`,
+        headers: { Authorization: 'Token jwt.token.here' },
+        query: { limit: 'number', offset: 'number' }
+      })
+    t.end()
+  })
+
+  t.end()
+})

--- a/test/sec/get-articles-slug.test.js
+++ b/test/sec/get-articles-slug.test.js
@@ -1,0 +1,57 @@
+'use strict'
+const t = require('tap')
+const startServer = require('../setup-server')
+const { SecRunner, TestType, AttackParamLocation, Severity } = require('@sectester/runner')
+
+let runner
+
+// Increase the timeout for the tests
+const testTimeout = 15 * 60 * 1000 // 15 minutes
+
+// Set the timeout for the tests
+jest.setTimeout(testTimeout)
+
+t.test('SecTester integration for GET /articles/{slug}', async t => {
+  let server
+  let baseUrl
+
+  t.before(async () => {
+    server = await startServer()
+    const address = server.server.address()
+    baseUrl = `http://localhost:${address.port}`
+  })
+
+  t.teardown(() => server.close())
+
+  t.beforeEach(async () => {
+    runner = new SecRunner({
+      hostname: process.env.BRIGHT_HOSTNAME
+    })
+    await runner.init()
+  })
+
+  t.afterEach(() => runner.clear())
+
+  t.test('Security tests for GET /articles/{slug}', async t => {
+    await runner.createScan({
+      tests: [
+        TestType.BROKEN_ACCESS_CONTROL,
+        'ID_ENUMERATION',
+        TestType.EXCESSIVE_DATA_EXPOSURE,
+        TestType.HTTP_METHOD_FUZZING,
+        TestType.XSS
+      ],
+      attackParamLocations: [AttackParamLocation.PATH]
+    })
+    .threshold(Severity.MEDIUM)
+    .timeout(testTimeout)
+    .run({
+      method: 'GET',
+      url: `${baseUrl}/articles/{slug}`
+    })
+
+    t.end()
+  })
+
+  t.end()
+})

--- a/test/sec/get-articles.test.js
+++ b/test/sec/get-articles.test.js
@@ -1,0 +1,55 @@
+'use strict'
+const t = require('tap')
+const startServer = require('../setup-server')
+const { SecRunner, TestType } = require('@sectester/runner')
+
+let runner
+
+// Increase the timeout for the tests
+const testTimeout = 15 * 60 * 1000 // 15 minutes
+
+// Set the timeout for the tests
+jest.setTimeout(testTimeout)
+
+t.test('SecTester integration for GET /articles', async t => {
+  let server
+  let baseUrl
+
+  t.before(async () => {
+    server = await startServer()
+    const address = server.server.address()
+    baseUrl = `http://localhost:${address.port}`
+  })
+
+  t.teardown(() => server.close())
+
+  t.beforeEach(async () => {
+    runner = new SecRunner({
+      hostname: process.env.BRIGHT_HOSTNAME
+    })
+    await runner.init()
+  })
+
+  t.afterEach(() => runner.clear())
+
+  // Placeholder for actual test cases
+  t.test('security tests for GET /articles', async t => {
+    await runner.createScan({
+      tests: [TestType.SQLI, TestType.XSS, 'excessive_data_exposure', 'http_method_fuzzing', 'id_enumeration'],
+      attackParamLocations: ['query']
+    }).threshold('medium').timeout(testTimeout).run({
+      method: 'GET',
+      url: `${baseUrl}/articles`,
+      query: {
+        tag: 'string',
+        author: 'string',
+        favorited: 'string',
+        limit: 10,
+        offset: 0
+      }
+    })
+    t.end()
+  })
+
+  t.end()
+})

--- a/test/sec/get-profiles-johndoe.test.js
+++ b/test/sec/get-profiles-johndoe.test.js
@@ -1,0 +1,54 @@
+'use strict'
+const t = require('tap')
+const startServer = require('../setup-server')
+const { SecRunner, TestType, AttackParamLocation, Severity } = require('@sectester/runner')
+
+let runner
+
+// Increase the timeout for the tests
+const testTimeout = 15 * 60 * 1000 // 15 minutes
+
+// Set the timeout for the tests
+jest.setTimeout(testTimeout)
+
+t.test('SecTester integration for GET /api/profiles/johndoe', async t => {
+  let server
+  let baseUrl
+
+  t.before(async () => {
+    server = await startServer()
+    const address = server.server.address()
+    baseUrl = `http://localhost:${address.port}`
+  })
+
+  t.teardown(() => server.close())
+
+  t.beforeEach(async () => {
+    runner = new SecRunner({
+      hostname: process.env.BRIGHT_HOSTNAME
+    })
+    await runner.init()
+  })
+
+  t.afterEach(() => runner.clear())
+
+  t.test('GET /api/profiles/johndoe', async t => {
+    await runner
+      .createScan({
+        tests: [TestType.BROKEN_ACCESS_CONTROL, TestType.JWT, 'EXCESSIVE_DATA_EXPOSURE'],
+        attackParamLocations: [AttackParamLocation.HEADER, AttackParamLocation.PATH]
+      })
+      .threshold(Severity.MEDIUM)
+      .timeout(testTimeout)
+      .run({
+        method: 'GET',
+        url: `${baseUrl}/api/profiles/johndoe`,
+        headers: {
+          Authorization: 'Token optional_jwt_token'
+        }
+      })
+    t.end()
+  })
+
+  t.end()
+})

--- a/test/sec/get-tags.js
+++ b/test/sec/get-tags.js
@@ -1,0 +1,54 @@
+'use strict'
+const t = require('tap')
+const startServer = require('../setup-server')
+const { SecRunner, TestType } = require('@sectester/runner')
+
+let runner
+
+// Increase the timeout for the tests
+const testTimeout = 15 * 60 * 1000 // 15 minutes
+
+// Set the timeout for the tests
+jest.setTimeout(testTimeout)
+
+t.test('SecTester integration for GET /tags', async t => {
+  let server
+  let baseUrl
+
+  t.before(async () => {
+    server = await startServer()
+    const address = server.server.address()
+    baseUrl = `http://localhost:${address.port}`
+  })
+
+  t.teardown(() => server.close())
+
+  t.beforeEach(async () => {
+    runner = new SecRunner({
+      hostname: process.env.BRIGHT_HOSTNAME
+    })
+    await runner.init()
+  })
+
+  t.afterEach(() => runner.clear())
+
+  t.test('excessive_data_exposure and http_method_fuzzing', async t => {
+    await runner.createScan({
+      tests: [
+        'excessive_data_exposure',
+        TestType.HTTP_METHOD_FUZZING
+      ],
+      attackParamLocations: []
+    })
+    .threshold('MEDIUM')
+    .timeout(testTimeout)
+    .run({
+      method: 'GET',
+      url: `${baseUrl}/tags`
+    })
+
+    t.end()
+  })
+
+  t.end()
+})

--- a/test/sec/post-api-profiles-username-follow.test.js
+++ b/test/sec/post-api-profiles-username-follow.test.js
@@ -1,0 +1,53 @@
+'use strict'
+const t = require('tap')
+const startServer = require('../setup-server')
+const { SecRunner, TestType, AttackParamLocation, Severity } = require('@sectester/runner')
+
+let runner
+
+// Increase the timeout for the tests
+const testTimeout = 15 * 60 * 1000 // 15 minutes
+
+// Set the timeout for the tests
+jest.setTimeout(testTimeout)
+
+t.test('SecTester integration for POST /api/profiles/:username/follow', async t => {
+  let server
+  let baseUrl
+
+  t.before(async () => {
+    server = await startServer()
+    const address = server.server.address()
+    baseUrl = `http://localhost:${address.port}`
+  })
+
+  t.teardown(() => server.close())
+
+  t.beforeEach(async () => {
+    runner = new SecRunner({
+      hostname: process.env.BRIGHT_HOSTNAME
+    })
+    await runner.init()
+  })
+
+  t.afterEach(() => runner.clear())
+
+  t.test('Security tests for POST /api/profiles/:username/follow', async t => {
+    await runner.createScan({
+      tests: [TestType.JWT, TestType.CSRF, TestType.BROKEN_ACCESS_CONTROL, 'HTTP_METHOD_FUZZING'],
+      attackParamLocations: [AttackParamLocation.HEADER, AttackParamLocation.BODY]
+    })
+    .threshold(Severity.MEDIUM)
+    .timeout(testTimeout)
+    .run({
+      method: 'POST',
+      url: `${baseUrl}/api/profiles/johndoe/follow`,
+      headers: { 'Authorization': 'Token required_jwt_token' },
+      body: {}
+    })
+
+    t.end()
+  })
+
+  t.end()
+})

--- a/test/sec/post-api-users-login.test.js
+++ b/test/sec/post-api-users-login.test.js
@@ -1,0 +1,59 @@
+'use strict'
+const t = require('tap')
+const startServer = require('../setup-server')
+const { SecRunner, TestType, AttackParamLocation, Severity } = require('@sectester/runner')
+
+let runner
+
+// Increase the timeout for the tests
+const testTimeout = 15 * 60 * 1000 // 15 minutes
+
+// Set the timeout for the tests
+jest.setTimeout(testTimeout)
+
+t.test('POST /api/users/login security tests', async t => {
+  let server
+  let baseUrl
+
+  t.before(async () => {
+    server = await startServer()
+    const address = server.server.address()
+    baseUrl = `http://localhost:${address.port}`
+  })
+
+  t.teardown(() => server.close())
+
+  t.beforeEach(async () => {
+    runner = new SecRunner({
+      hostname: process.env.BRIGHT_HOSTNAME
+    })
+    await runner.init()
+  })
+
+  t.afterEach(() => runner.clear())
+
+  t.test('Security tests for POST /api/users/login', async t => {
+    await runner
+      .createScan({
+        tests: [TestType.BruteForce, TestType.Csrf, TestType.Sqli, TestType.Xss],
+        attackParamLocations: [AttackParamLocation.BODY]
+      })
+      .threshold(Severity.MEDIUM)
+      .timeout(testTimeout)
+      .run({
+        method: 'POST',
+        url: `${baseUrl}/api/users/login`,
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          user: {
+            email: 'user@example.com',
+            password: 'password123'
+          }
+        })
+      })
+
+    t.end()
+  })
+
+  t.end()
+})

--- a/test/sec/post-api-users.test.js
+++ b/test/sec/post-api-users.test.js
@@ -1,0 +1,71 @@
+'use strict'
+const t = require('tap')
+const startServer = require('../setup-server')
+const { SecRunner, TestType, AttackParamLocation, Severity } = require('@sectester/runner')
+
+let runner
+
+// Increase the timeout for the tests
+const testTimeout = 15 * 60 * 1000 // 15 minutes
+
+// Set the timeout for the tests
+jest.setTimeout(testTimeout)
+
+t.test('SecTester integration for POST /api/users', async t => {
+  let server
+  let baseUrl
+
+  t.before(async () => {
+    server = await startServer()
+    const address = server.server.address()
+    baseUrl = `http://localhost:${address.port}`
+  })
+
+  t.teardown(() => server.close())
+
+  t.beforeEach(async () => {
+    runner = new SecRunner({
+      hostname: process.env.BRIGHT_HOSTNAME
+    })
+    await runner.init()
+  })
+
+  t.afterEach(() => runner.clear())
+
+  t.test('Security tests for POST /api/users', async t => {
+    await runner
+      .createScan({
+        tests: [
+          TestType.BRUTE_FORCE_LOGIN,
+          TestType.CSRF,
+          TestType.EXCESSIVE_DATA_EXPOSURE,
+          TestType.MASS_ASSIGNMENT,
+          TestType.SQLI,
+          TestType.XSS
+        ],
+        attackParamLocations: [
+          AttackParamLocation.BODY
+        ]
+      })
+      .threshold(Severity.MEDIUM)
+      .timeout(testTimeout)
+      .run({
+        method: 'POST',
+        url: `${baseUrl}/api/users`,
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({
+          user: {
+            username: 'newuser',
+            email: 'newuser@example.com',
+            password: 'password123'
+          }
+        })
+      })
+
+    t.end()
+  })
+
+  t.end()
+})

--- a/test/sec/post-articles-example-article-comments.test.js
+++ b/test/sec/post-articles-example-article-comments.test.js
@@ -1,0 +1,71 @@
+'use strict'
+const t = require('tap')
+const startServer = require('../setup-server')
+const { SecRunner, TestType, AttackParamLocation, Severity } = require('@sectester/runner')
+
+let runner
+
+// Increase the timeout for the tests
+const testTimeout = 15 * 60 * 1000 // 15 minutes
+
+// Set the timeout for the tests
+jest.setTimeout(testTimeout)
+
+t.test('POST /articles/example-article/comments', async t => {
+  let server
+  let baseUrl
+
+  t.before(async () => {
+    server = await startServer()
+    const address = server.server.address()
+    baseUrl = `http://localhost:${address.port}`
+  })
+
+  t.teardown(() => server.close())
+
+  t.beforeEach(async () => {
+    runner = new SecRunner({
+      hostname: process.env.BRIGHT_HOSTNAME
+    })
+    await runner.init()
+  })
+
+  t.afterEach(() => runner.clear())
+
+  t.test('security tests', async t => {
+    await runner
+      .createScan({
+        tests: [
+          TestType.CSRF,
+          TestType.JWT,
+          TestType.XSS,
+          TestType.SQLI,
+          'excessive_data_exposure',
+          'broken_access_control'
+        ],
+        attackParamLocations: [
+          AttackParamLocation.BODY,
+          AttackParamLocation.HEADER
+        ]
+      })
+      .threshold(Severity.MEDIUM)
+      .timeout(testTimeout)
+      .run({
+        method: 'POST',
+        url: `${baseUrl}/articles/example-article/comments`,
+        headers: {
+          Authorization: 'Bearer <token>',
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({
+          comment: {
+            body: 'This is a comment.'
+          }
+        })
+      })
+
+    t.end()
+  })
+
+  t.end()
+})

--- a/test/sec/post-articles-slug-favorite.test.js
+++ b/test/sec/post-articles-slug-favorite.test.js
@@ -1,0 +1,55 @@
+'use strict'
+const t = require('tap')
+const startServer = require('../setup-server')
+const { SecRunner, TestType, AttackParamLocation, Severity } = require('@sectester/runner')
+
+let runner
+
+// Increase the timeout for the tests
+const testTimeout = 15 * 60 * 1000 // 15 minutes
+
+// Set the timeout for the tests
+jest.setTimeout(testTimeout)
+
+t.test('SecTester integration for POST /articles/{slug}/favorite', async t => {
+  let server
+  let baseUrl
+
+  t.before(async () => {
+    server = await startServer()
+    const address = server.server.address()
+    baseUrl = `http://localhost:${address.port}`
+  })
+
+  t.teardown(() => server.close())
+
+  t.beforeEach(async () => {
+    runner = new SecRunner({
+      hostname: process.env.BRIGHT_HOSTNAME
+    })
+    await runner.init()
+  })
+
+  t.afterEach(() => runner.clear())
+
+  t.test('Security tests for POST /articles/{slug}/favorite', async t => {
+    await runner.createScan({
+      tests: [TestType.JWT, TestType.CSRF, TestType.BROKEN_ACCESS_CONTROL, 'http_method_fuzzing', TestType.XSS],
+      attackParamLocations: [AttackParamLocation.BODY, AttackParamLocation.HEADER]
+    })
+    .threshold(Severity.MEDIUM)
+    .timeout(testTimeout)
+    .run({
+      method: 'POST',
+      url: `${baseUrl}/articles/test-slug/favorite`,
+      headers: {
+        'Authorization': 'Token jwt.token.here'
+      },
+      body: {}
+    })
+
+    t.end()
+  })
+
+  t.end()
+})

--- a/test/sec/post-articles.test.js
+++ b/test/sec/post-articles.test.js
@@ -1,0 +1,64 @@
+'use strict'
+const t = require('tap')
+const startServer = require('../setup-server')
+const { SecRunner, TestType, AttackParamLocation, Severity } = require('@sectester/runner')
+
+let runner
+
+// Increase the timeout for the tests
+const testTimeout = 15 * 60 * 1000 // 15 minutes
+
+// Set the timeout for the tests
+jest.setTimeout(testTimeout)
+
+t.test('SecTester integration for POST /articles', async t => {
+  let server
+  let baseUrl
+
+  t.before(async () => {
+    server = await startServer()
+    const address = server.server.address()
+    baseUrl = `http://localhost:${address.port}`
+  })
+
+  t.teardown(() => server.close())
+
+  t.beforeEach(async () => {
+    runner = new SecRunner({
+      hostname: process.env.BRIGHT_HOSTNAME
+    })
+    await runner.init()
+  })
+
+  t.afterEach(() => runner.clear())
+
+  // Placeholder for actual test cases
+  t.test('POST /articles', async t => {
+    await runner
+      .createScan({
+        tests: [TestType.JWT, TestType.CSRF, TestType.MASS_ASSIGNMENT, TestType.XSS, TestType.SQLI],
+        attackParamLocations: [AttackParamLocation.BODY, AttackParamLocation.HEADER]
+      })
+      .threshold(Severity.MEDIUM)
+      .timeout(testTimeout)
+      .run({
+        method: 'POST',
+        url: `${baseUrl}/articles`,
+        headers: {
+          'Authorization': 'Token jwt.token.here',
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({
+          article: {
+            title: 'string',
+            description: 'string',
+            body: 'string',
+            tagList: ['string']
+          }
+        })
+      })
+    t.end()
+  })
+
+  t.end()
+})

--- a/test/sec/post-sentiment-score.test.js
+++ b/test/sec/post-sentiment-score.test.js
@@ -1,0 +1,64 @@
+'use strict'
+const t = require('tap')
+const startServer = require('../setup-server')
+const { SecRunner, TestType, AttackParamLocation, Severity } = require('@sectester/runner')
+
+let runner
+
+// Increase the timeout for the tests
+const testTimeout = 15 * 60 * 1000 // 15 minutes
+
+// Set the timeout for the tests
+jest.setTimeout(testTimeout)
+
+t.test('SecTester integration for POST /sentiment/score', async t => {
+  let server
+  let baseUrl
+
+  t.before(async () => {
+    server = await startServer()
+    const address = server.server.address()
+    baseUrl = `http://localhost:${address.port}`
+  })
+
+  t.teardown(() => server.close())
+
+  t.beforeEach(async () => {
+    runner = new SecRunner({
+      hostname: process.env.BRIGHT_HOSTNAME
+    })
+    await runner.init()
+  })
+
+  t.afterEach(() => runner.clear())
+
+  // Placeholder for actual test cases
+  t.test('Security tests for POST /sentiment/score', async t => {
+    await runner.createScan({
+      tests: [
+        TestType.CSRF,
+        TestType.XSS,
+        TestType.SQLI,
+        'excessive_data_exposure',
+        'business_constraint_bypass'
+      ],
+      attackParamLocations: [AttackParamLocation.BODY]
+    })
+    .threshold(Severity.MEDIUM)
+    .timeout(testTimeout)
+    .run({
+      method: 'POST',
+      url: `${baseUrl}/sentiment/score`,
+      headers: {
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({
+        content: 'string'
+      })
+    })
+
+    t.end()
+  })
+
+  t.end()
+})

--- a/test/sec/put-api-user.test.js
+++ b/test/sec/put-api-user.test.js
@@ -1,0 +1,73 @@
+'use strict'
+const t = require('tap')
+const startServer = require('../setup-server')
+const { SecRunner, TestType, AttackParamLocation, Severity } = require('@sectester/runner')
+
+let runner
+
+// Increase the timeout for the tests
+const testTimeout = 15 * 60 * 1000 // 15 minutes
+
+// Set the timeout for the tests
+jest.setTimeout(testTimeout)
+
+t.test('PUT /api/user', async t => {
+  let server
+  let baseUrl
+
+  t.before(async () => {
+    server = await startServer()
+    const address = server.server.address()
+    baseUrl = `http://localhost:${address.port}`
+  })
+
+  t.teardown(() => server.close())
+
+  t.beforeEach(async () => {
+    runner = new SecRunner({
+      hostname: process.env.BRIGHT_HOSTNAME
+    })
+    await runner.init()
+  })
+
+  t.afterEach(() => runner.clear())
+
+  t.test('Security tests for PUT /api/user', async t => {
+    await runner
+      .createScan({
+        tests: [
+          TestType.JWT,
+          TestType.CSRF,
+          TestType.BRUTE_FORCE_LOGIN,
+          TestType.EXCESSIVE_DATA_EXPOSURE,
+          TestType.MASS_ASSIGNMENT,
+          TestType.SQLI,
+          TestType.XSS
+        ],
+        attackParamLocations: [
+          AttackParamLocation.BODY,
+          AttackParamLocation.HEADER
+        ]
+      })
+      .threshold(Severity.MEDIUM)
+      .timeout(testTimeout)
+      .run({
+        method: 'PUT',
+        url: `${baseUrl}/api/user`,
+        headers: {
+          'Authorization': 'Bearer <token>',
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({
+          user: {
+            email: 'updateduser@example.com',
+            password: 'newpassword123'
+          }
+        })
+      })
+
+    t.end()
+  })
+
+  t.end()
+})

--- a/test/sec/put-articles-slug.test.js
+++ b/test/sec/put-articles-slug.test.js
@@ -1,0 +1,59 @@
+'use strict'
+const t = require('tap')
+const startServer = require('../setup-server')
+const { SecRunner, TestType, AttackParamLocation, Severity } = require('@sectester/runner')
+
+let runner
+
+// Increase the timeout for the tests
+const testTimeout = 15 * 60 * 1000 // 15 minutes
+
+// Set the timeout for the tests
+jest.setTimeout(testTimeout)
+
+t.test('SecTester integration for PUT /articles/{slug}', async t => {
+  let server
+  let baseUrl
+
+  t.before(async () => {
+    server = await startServer()
+    const address = server.server.address()
+    baseUrl = `http://localhost:${address.port}`
+  })
+
+  t.teardown(() => server.close())
+
+  t.beforeEach(async () => {
+    runner = new SecRunner({
+      hostname: process.env.BRIGHT_HOSTNAME
+    })
+    await runner.init()
+  })
+
+  t.afterEach(() => runner.clear())
+
+  t.test('PUT /articles/{slug}', async t => {
+    await runner.createScan({
+      tests: [TestType.JWT, TestType.CSRF, TestType.MASS_ASSIGNMENT, TestType.XSS, TestType.SQLI],
+      attackParamLocations: [AttackParamLocation.BODY, AttackParamLocation.HEADER]
+    })
+    .threshold(Severity.MEDIUM)
+    .timeout(testTimeout)
+    .run({
+      method: 'PUT',
+      url: `${baseUrl}/articles/{slug}`,
+      headers: { 'Authorization': 'Token jwt.token.here' },
+      body: JSON.stringify({
+        article: {
+          title: 'string',
+          description: 'string',
+          body: 'string'
+        }
+      })
+    })
+
+    t.end()
+  })
+
+  t.end()
+})


### PR DESCRIPTION
## Description

Adds SecTester security tests for the following endpoints:
- GET /articles
- GET /articles/feed
- GET /articles/{slug}
- POST /articles
- PUT /articles/{slug}
- DELETE /articles/{slug}
- POST /articles/{slug}/favorite
- DELETE /articles/{slug}/favorite
- GET /articles/example-article/comments
- POST /articles/example-article/comments
- DELETE /articles/example-article/comments/1
- GET http://localhost:3000/api/profiles/johndoe
- POST http://localhost:3000/api/profiles/johndoe/follow
- DELETE http://localhost:3000/api/profiles/johndoe/follow
- POST http://localhost:3000/sentiment/score
- GET http://localhost:3000/tags
- POST http://localhost:3000/api/users/login
- POST http://localhost:3000/api/users
- GET http://localhost:3000/api/user
- PUT http://localhost:3000/api/user

Tests cover:
- SQL injection
- XSS vulnerabilities
- Authentication bypass

## Test Plan

- Validate that all security tests pass without any issues
- Ensure that endpoints are protected against common security threats

## Endpoints Tested

- GET /articles
- GET /articles/feed
- GET /articles/{slug}
- POST /articles
- PUT /articles/{slug}
- DELETE /articles/{slug}
- POST /articles/{slug}/favorite
- DELETE /articles/{slug}/favorite
- GET /articles/example-article/comments
- POST /articles/example-article/comments
- DELETE /articles/example-article/comments/1
- GET http://localhost:3000/api/profiles/johndoe
- POST http://localhost:3000/api/profiles/johndoe/follow
- DELETE http://localhost:3000/api/profiles/johndoe/follow
- POST http://localhost:3000/sentiment/score
- GET http://localhost:3000/tags
- POST http://localhost:3000/api/users/login
- POST http://localhost:3000/api/users
- GET http://localhost:3000/api/user
- PUT http://localhost:3000/api/user