### PR TITLE
test(security): add security tests for article and profile endpoints

### DIFF
--- a/.github/workflows/bright.yml
+++ b/.github/workflows/bright.yml
@@ -1,0 +1,29 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - '**'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    env:
+      BRIGHT_HOSTNAME: ${{ vars.BRIGHT_HOSTNAME }}
+      BRIGHT_TOKEN: ${{ secrets.BRIGHT_TOKEN }}
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
+    - name: Set up Node.js
+      uses: actions/setup-node@v2
+      with:
+        node-version: '14'
+
+    - name: Install dependencies
+      run: npm install
+
+    - name: Run tests
+      run: npm test -- test/sec/**/*.test.js

--- a/test/sec/delete-articles-example-slug-comments-id.test.js
+++ b/test/sec/delete-articles-example-slug-comments-id.test.js
@@ -1,0 +1,45 @@
+'use strict'
+const t = require('tap')
+const startServer = require('../setup-server')
+const { SecRunner, TestType, AttackParamLocation, Severity } = require('@sectester/runner')
+
+let runner
+
+// Increase the timeout for the tests
+jest.setTimeout(15 * 60 * 1000) // 15 minutes
+
+t.test('DELETE /articles/example-slug/comments/123', async t => {
+  let server
+
+  t.beforeEach(async () => {
+    server = await startServer()
+    runner = new SecRunner({
+      hostname: process.env.BRIGHT_HOSTNAME
+    })
+    await runner.init()
+  })
+
+  t.teardown(async () => {
+    await runner.clear()
+    await server.close()
+  })
+
+  it('Security tests for DELETE /articles/example-slug/comments/123', async () => {
+    await runner
+      .createScan({
+        tests: [TestType.BROKEN_ACCESS_CONTROL, TestType.JWT, 'id_enumeration'],
+        attackParamLocations: [AttackParamLocation.PATH]
+      })
+      .threshold(Severity.MEDIUM)
+      .timeout(15 * 60 * 1000)
+      .run({
+        method: 'DELETE',
+        url: `${server.baseUrl}/articles/example-slug/comments/123`,
+        headers: {
+          Authorization: 'Token required-jwt-token'
+        }
+      })
+  })
+
+  t.end()
+})

--- a/test/sec/delete-articles-slug-favorite.test.js
+++ b/test/sec/delete-articles-slug-favorite.test.js
@@ -1,0 +1,44 @@
+'use strict'
+const t = require('tap')
+const startServer = require('../setup-server')
+const { SecRunner, TestType, AttackParamLocation, Severity } = require('@sectester/runner')
+
+let runner
+
+// Increase the timeout for the tests
+jest.setTimeout(15 * 60 * 1000) // 15 minutes
+
+t.test('DELETE /articles/{slug}/favorite', async t => {
+  let server
+
+  t.beforeEach(async () => {
+    server = await startServer()
+    runner = new SecRunner({
+      hostname: process.env.BRIGHT_HOSTNAME
+    })
+    await runner.init()
+  })
+
+  t.teardown(async () => {
+    await runner.clear()
+    await server.close()
+  })
+
+  t.test('Security tests', async t => {
+    await runner.createScan({
+      tests: [TestType.JWT, TestType.BROKEN_ACCESS_CONTROL, 'CSRF', TestType.HTTP_METHOD_FUZZING],
+      attackParamLocations: [AttackParamLocation.PATH]
+    })
+    .threshold(Severity.MEDIUM)
+    .timeout(15 * 60 * 1000)
+    .run({
+      method: 'DELETE',
+      url: `${server.baseUrl}/articles/{slug}/favorite`,
+      headers: { 'Authorization': 'Token jwt.token.here' }
+    })
+
+    t.end()
+  })
+
+  t.end()
+})

--- a/test/sec/delete-articles-slug.test.js
+++ b/test/sec/delete-articles-slug.test.js
@@ -1,0 +1,40 @@
+'use strict'
+const t = require('tap')
+const startServer = require('../setup-server')
+const { SecRunner, TestType, AttackParamLocation, Severity } = require('@sectester/runner')
+
+let runner
+
+// Increase the timeout for the tests
+jest.setTimeout(15 * 60 * 1000) // 15 minutes
+
+t.test('DELETE /articles/:slug', async t => {
+  let server
+
+  t.beforeEach(async () => {
+    server = await startServer()
+    runner = new SecRunner({
+      hostname: process.env.BRIGHT_HOSTNAME
+    })
+    await runner.init()
+  })
+
+  t.teardown(async () => {
+    await runner.clear()
+    await server.close()
+  })
+
+  await runner.createScan({
+    tests: [TestType.BROKEN_ACCESS_CONTROL, TestType.JWT, 'http_method_fuzzing'],
+    attackParamLocations: [AttackParamLocation.PATH]
+  })
+  .threshold(Severity.MEDIUM)
+  .timeout(15 * 60 * 1000) // 15 minutes
+  .run({
+    method: 'DELETE',
+    url: `${server.baseUrl}/articles/{slug}`,
+    headers: [{ name: 'Authorization', value: 'Token jwt.token.here' }]
+  })
+
+  t.end()
+})

--- a/test/sec/delete-profiles-username-follow.test.js
+++ b/test/sec/delete-profiles-username-follow.test.js
@@ -1,0 +1,40 @@
+'use strict'
+const t = require('tap')
+const startServer = require('../setup-server')
+const { SecRunner, TestType, AttackParamLocation, Severity } = require('@sectester/runner')
+
+let runner
+
+// Increase the timeout for the tests
+jest.setTimeout(15 * 60 * 1000) // 15 minutes
+
+t.test('DELETE /api/profiles/:username/follow', async t => {
+  let server
+
+  t.beforeEach(async () => {
+    server = await startServer()
+    runner = new SecRunner({
+      hostname: process.env.BRIGHT_HOSTNAME
+    })
+    await runner.init()
+  })
+
+  t.teardown(async () => {
+    await runner.clear()
+    await server.close()
+  })
+
+  await runner.createScan({
+    tests: [TestType.BROKEN_ACCESS_CONTROL, TestType.JWT, TestType.CSRF, 'HTTP_METHOD_FUZZING'],
+    attackParamLocations: [AttackParamLocation.HEADER, AttackParamLocation.BODY, AttackParamLocation.PATH]
+  })
+  .threshold(Severity.MEDIUM)
+  .timeout(15 * 60 * 1000)
+  .run({
+    method: 'DELETE',
+    url: 'http://localhost:3000/api/profiles/johndoe/follow',
+    headers: { 'Authorization': 'Token required_jwt_token' }
+  })
+
+  t.end()
+})

--- a/test/sec/get-api-user.test.js
+++ b/test/sec/get-api-user.test.js
@@ -1,0 +1,44 @@
+'use strict'
+const t = require('tap')
+const startServer = require('../setup-server')
+const { SecRunner, TestType, AttackParamLocation, Severity } = require('@sectester/runner')
+
+let runner
+
+// Increase the timeout for the tests
+jest.setTimeout(15 * 60 * 1000) // 15 minutes
+
+t.test('Security tests for GET /api/user', async t => {
+  let server
+
+  t.beforeEach(async () => {
+    server = await startServer()
+    runner = new SecRunner({
+      hostname: process.env.BRIGHT_HOSTNAME
+    })
+    await runner.init()
+  })
+
+  t.teardown(async () => {
+    await runner.clear()
+    await server.close()
+  })
+
+  t.test('GET /api/user', async t => {
+    await runner.createScan({
+      tests: [TestType.BROKEN_ACCESS_CONTROL, TestType.JWT, 'excessive_data_exposure'],
+      attackParamLocations: [AttackParamLocation.HEADER]
+    })
+    .threshold(Severity.MEDIUM)
+    .timeout(15 * 60 * 1000)
+    .run({
+      method: 'GET',
+      url: 'http://localhost:3000/api/user',
+      headers: { 'Authorization': 'Bearer <token>' }
+    })
+
+    t.end()
+  })
+
+  t.end()
+})

--- a/test/sec/get-articles-example-slug-comments.test.js
+++ b/test/sec/get-articles-example-slug-comments.test.js
@@ -1,0 +1,46 @@
+'use strict'
+const t = require('tap')
+const startServer = require('../setup-server')
+const { SecRunner, TestType, AttackParamLocation, Severity } = require('@sectester/runner')
+
+let runner
+
+// Increase the timeout for the tests
+jest.setTimeout(15 * 60 * 1000) // 15 minutes
+
+t.test('Security tests for GET /articles/example-slug/comments', async t => {
+  let server
+
+  t.beforeEach(async () => {
+    server = await startServer()
+    runner = new SecRunner({
+      hostname: process.env.BRIGHT_HOSTNAME
+    })
+    await runner.init()
+  })
+
+  t.teardown(async () => {
+    await runner.clear()
+    await server.close()
+  })
+
+  t.test('GET /articles/example-slug/comments', async t => {
+    await runner
+      .createScan({
+        tests: [TestType.JWT, TestType.BROKEN_ACCESS_CONTROL, 'excessive_data_exposure'],
+        attackParamLocations: [AttackParamLocation.HEADER, AttackParamLocation.PATH]
+      })
+      .threshold(Severity.MEDIUM)
+      .timeout(15 * 60 * 1000)
+      .run({
+        method: 'GET',
+        url: `${server.baseUrl}/articles/example-slug/comments`,
+        headers: {
+          Authorization: 'Token optional-jwt-token'
+        }
+      })
+    t.end()
+  })
+
+  t.end()
+})

--- a/test/sec/get-articles-feed.test.js
+++ b/test/sec/get-articles-feed.test.js
@@ -1,0 +1,45 @@
+'use strict'
+const t = require('tap')
+const startServer = require('../setup-server')
+const { SecRunner, TestType, AttackParamLocation, Severity } = require('@sectester/runner')
+
+let runner
+
+// Increase the timeout for the tests
+jest.setTimeout(15 * 60 * 1000) // 15 minutes
+
+t.test('Security tests for GET /articles/feed', async t => {
+  let server
+
+  t.beforeEach(async () => {
+    server = await startServer()
+    runner = new SecRunner({
+      hostname: process.env.BRIGHT_HOSTNAME
+    })
+    await runner.init()
+  })
+
+  t.teardown(async () => {
+    await runner.clear()
+    await server.close()
+  })
+
+  t.test('GET /articles/feed', async t => {
+    await runner.createScan({
+      tests: [TestType.JWT, TestType.BROKEN_ACCESS_CONTROL, TestType.EXCESSIVE_DATA_EXPOSURE, 'HTTP_METHOD_FUZZING', 'ID_ENUMERATION'],
+      attackParamLocations: [AttackParamLocation.QUERY, AttackParamLocation.HEADER]
+    })
+    .threshold(Severity.MEDIUM)
+    .timeout(15 * 60 * 1000)
+    .run({
+      method: 'GET',
+      url: `${server.baseUrl}/articles/feed`,
+      headers: { 'Authorization': 'Token jwt.token.here' },
+      query: { limit: 'integer', offset: 'integer' }
+    })
+
+    t.end()
+  })
+
+  t.end()
+})

--- a/test/sec/get-articles-slug.test.js
+++ b/test/sec/get-articles-slug.test.js
@@ -1,0 +1,48 @@
+'use strict'
+const t = require('tap')
+const startServer = require('../setup-server')
+const { SecRunner, TestType, AttackParamLocation, Severity } = require('@sectester/runner')
+
+let runner
+
+// Increase the timeout for the tests
+jest.setTimeout(15 * 60 * 1000) // 15 minutes
+
+t.test('Security tests for GET /articles/{slug}', async t => {
+  let server
+
+  t.beforeEach(async () => {
+    server = await startServer()
+    runner = new SecRunner({
+      hostname: process.env.BRIGHT_HOSTNAME
+    })
+    await runner.init()
+  })
+
+  t.teardown(async () => {
+    await runner.clear()
+    await server.close()
+  })
+
+  t.test('GET /articles/{slug}', async t => {
+    await runner.createScan({
+      tests: [
+        TestType.BROKEN_ACCESS_CONTROL,
+        'id_enumeration',
+        TestType.EXCESSIVE_DATA_EXPOSURE,
+        TestType.XSS
+      ],
+      attackParamLocations: [AttackParamLocation.PATH]
+    })
+    .threshold(Severity.MEDIUM)
+    .timeout(15 * 60 * 1000)
+    .run({
+      method: 'GET',
+      url: `${server.baseUrl}/articles/{slug}`
+    })
+
+    t.end()
+  })
+
+  t.end()
+})

--- a/test/sec/get-articles.test.js
+++ b/test/sec/get-articles.test.js
@@ -1,0 +1,49 @@
+'use strict'
+const t = require('tap')
+const startServer = require('../setup-server')
+const { SecRunner, TestType } = require('@sectester/runner')
+
+let runner
+
+// Increase the timeout for the tests
+jest.setTimeout(15 * 60 * 1000) // 15 minutes
+
+t.test('Security tests for GET /articles', async t => {
+  let server
+
+  t.beforeEach(async () => {
+    server = await startServer()
+    runner = new SecRunner({
+      hostname: process.env.BRIGHT_HOSTNAME
+    })
+    await runner.init()
+  })
+
+  t.teardown(async () => {
+    await runner.clear()
+    await server.close()
+  })
+
+  t.test('should test for security vulnerabilities', async t => {
+    await runner.createScan({
+      tests: [TestType.SQLI, TestType.XSS, 'excessive_data_exposure', 'http_method_fuzzing', 'id_enumeration'],
+      attackParamLocations: ['query']
+    })
+    .threshold('medium')
+    .timeout(15 * 60 * 1000)
+    .run({
+      method: 'GET',
+      url: '/articles',
+      query: {
+        tag: 'string',
+        author: 'string',
+        favorited: 'string',
+        limit: 10,
+        offset: 0
+      }
+    })
+    t.end()
+  })
+
+  t.end()
+})

--- a/test/sec/get-profiles-johndoe.test.js
+++ b/test/sec/get-profiles-johndoe.test.js
@@ -1,0 +1,44 @@
+'use strict'
+const t = require('tap')
+const startServer = require('../setup-server')
+const { SecRunner, TestType, AttackParamLocation, Severity } = require('@sectester/runner')
+
+let runner
+
+// Increase the timeout for the tests
+jest.setTimeout(15 * 60 * 1000) // 15 minutes
+
+t.test('Security tests for GET /api/profiles/johndoe', async t => {
+  let server
+
+  t.beforeEach(async () => {
+    server = await startServer()
+    runner = new SecRunner({
+      hostname: process.env.BRIGHT_HOSTNAME
+    })
+    await runner.init()
+  })
+
+  t.teardown(async () => {
+    await runner.clear()
+    await server.close()
+  })
+
+  t.test('GET /api/profiles/johndoe', async t => {
+    await runner.createScan({
+      tests: [TestType.BROKEN_ACCESS_CONTROL, TestType.JWT, 'EXCESSIVE_DATA_EXPOSURE'],
+      attackParamLocations: [AttackParamLocation.HEADER, AttackParamLocation.PATH]
+    })
+    .threshold(Severity.MEDIUM)
+    .timeout(15 * 60 * 1000)
+    .run({
+      method: 'GET',
+      url: 'http://localhost:3000/api/profiles/johndoe',
+      headers: { 'Authorization': 'Token optional_jwt_token' }
+    })
+
+    t.end()
+  })
+
+  t.end()
+})

--- a/test/sec/get-tags.test.js
+++ b/test/sec/get-tags.test.js
@@ -1,0 +1,43 @@
+'use strict'
+const t = require('tap')
+const startServer = require('../setup-server')
+const { SecRunner, TestType, AttackParamLocation, Severity } = require('@sectester/runner')
+
+let runner
+
+// Increase the timeout for the tests
+jest.setTimeout(15 * 60 * 1000) // 15 minutes
+
+t.test('Security tests for GET /tags', async t => {
+  let server
+
+  t.beforeEach(async () => {
+    server = await startServer()
+    runner = new SecRunner({
+      hostname: process.env.BRIGHT_HOSTNAME
+    })
+    await runner.init()
+  })
+
+  t.teardown(async () => {
+    await runner.clear()
+    await server.close()
+  })
+
+  t.test('Excessive Data Exposure and HTTP Method Fuzzing', async t => {
+    await runner.createScan({
+      tests: [TestType.EXCESSIVE_DATA_EXPOSURE, 'HTTP_METHOD_FUZZING'],
+      attackParamLocations: [AttackParamLocation.QUERY]
+    })
+    .threshold(Severity.MEDIUM)
+    .timeout(15 * 60 * 1000)
+    .run({
+      method: 'GET',
+      url: `${server.baseUrl}/tags`
+    })
+
+    t.end()
+  })
+
+  t.end()
+})

--- a/test/sec/post-api-users-login.test.js
+++ b/test/sec/post-api-users-login.test.js
@@ -1,0 +1,45 @@
+'use strict'
+const t = require('tap')
+const startServer = require('../setup-server')
+const { SecRunner, TestType } = require('@sectester/runner')
+
+let runner
+
+// Increase the timeout for the tests
+jest.setTimeout(15 * 60 * 1000) // 15 minutes
+
+t.test('Security tests for POST /api/users/login', async t => {
+  let server
+
+  t.beforeEach(async () => {
+    server = await startServer()
+    runner = new SecRunner({
+      hostname: process.env.BRIGHT_HOSTNAME
+    })
+    await runner.init()
+  })
+
+  t.teardown(async () => {
+    await runner.clear()
+    await server.close()
+  })
+
+  t.test('should perform security tests', async t => {
+    await runner.createScan({
+      tests: [TestType.BRUTE_FORCE, TestType.CSRF, TestType.SQLI, TestType.XSS],
+      attackParamLocations: ['body', 'header']
+    })
+    .threshold('medium')
+    .timeout(15 * 60 * 1000)
+    .run({
+      method: 'POST',
+      url: 'http://localhost:3000/api/users/login',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ user: { email: 'example@example.com', password: 'password123' } })
+    })
+
+    t.end()
+  })
+
+  t.end()
+})

--- a/test/sec/post-api-users.test.js
+++ b/test/sec/post-api-users.test.js
@@ -1,0 +1,59 @@
+'use strict'
+const t = require('tap')
+const startServer = require('../setup-server')
+const { SecRunner, TestType, AttackParamLocation, Severity } = require('@sectester/runner')
+
+let runner
+
+// Increase the timeout for the tests
+jest.setTimeout(15 * 60 * 1000) // 15 minutes
+
+t.test('Security tests for POST /api/users', async t => {
+  let server
+
+  t.beforeEach(async () => {
+    server = await startServer()
+    runner = new SecRunner({
+      hostname: process.env.BRIGHT_HOSTNAME
+    })
+    await runner.init()
+  })
+
+  t.teardown(async () => {
+    await runner.clear()
+    await server.close()
+  })
+
+  t.test('POST /api/users', async t => {
+    await runner.createScan({
+      tests: [
+        TestType.BRUTE_FORCE_LOGIN,
+        TestType.CSRF,
+        'EMAIL_INJECTION',
+        TestType.EXCESSIVE_DATA_EXPOSURE,
+        TestType.MASS_ASSIGNMENT,
+        TestType.SQLI,
+        TestType.XSS
+      ],
+      attackParamLocations: [AttackParamLocation.BODY]
+    })
+    .threshold(Severity.MEDIUM)
+    .timeout(15 * 60 * 1000)
+    .run({
+      method: 'POST',
+      url: 'http://localhost:3000/api/users',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        user: {
+          username: 'newuser',
+          email: 'newuser@example.com',
+          password: 'password123'
+        }
+      })
+    })
+
+    t.end()
+  })
+
+  t.end()
+})

--- a/test/sec/post-articles-example-slug-comments.test.js
+++ b/test/sec/post-articles-example-slug-comments.test.js
@@ -1,0 +1,52 @@
+'use strict'
+const t = require('tap')
+const startServer = require('../setup-server')
+const { SecRunner, TestType, AttackParamLocation, Severity } = require('@sectester/runner')
+
+let runner
+
+// Increase the timeout for the tests
+jest.setTimeout(15 * 60 * 1000) // 15 minutes
+
+t.test('Security tests for POST /articles/example-slug/comments', async t => {
+  let server
+
+  t.beforeEach(async () => {
+    server = await startServer()
+    runner = new SecRunner({
+      hostname: process.env.BRIGHT_HOSTNAME
+    })
+    await runner.init()
+  })
+
+  t.teardown(async () => {
+    await runner.clear()
+    await server.close()
+  })
+
+  t.test('POST /articles/example-slug/comments', async t => {
+    await runner.createScan({
+      tests: [TestType.JWT, TestType.CSRF, TestType.XSS, TestType.SQLI, 'mass_assignment'],
+      attackParamLocations: [AttackParamLocation.BODY, AttackParamLocation.HEADER]
+    })
+    .threshold(Severity.MEDIUM)
+    .timeout(15 * 60 * 1000)
+    .run({
+      method: 'POST',
+      url: '/articles/example-slug/comments',
+      headers: {
+        'Authorization': 'Token required-jwt-token',
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({
+        comment: {
+          body: 'This is a comment.'
+        }
+      })
+    })
+
+    t.end()
+  })
+
+  t.end()
+})

--- a/test/sec/post-articles-slug-favorite.test.js
+++ b/test/sec/post-articles-slug-favorite.test.js
@@ -1,0 +1,43 @@
+'use strict'
+const t = require('tap')
+const startServer = require('../setup-server')
+const { SecRunner, TestType, AttackParamLocation, Severity } = require('@sectester/runner')
+
+let runner
+
+// Increase the timeout for the tests
+jest.setTimeout(15 * 60 * 1000) // 15 minutes
+
+t.test('Security tests for POST /articles/{slug}/favorite', async t => {
+  let server
+
+  t.beforeEach(async () => {
+    server = await startServer()
+    runner = new SecRunner({
+      hostname: process.env.BRIGHT_HOSTNAME
+    })
+    await runner.init()
+  })
+
+  t.teardown(async () => {
+    await runner.clear()
+    await server.close()
+  })
+
+  it('POST /articles/{slug}/favorite', async () => {
+    await runner
+      .createScan({
+        tests: [TestType.JWT, TestType.CSRF, TestType.BROKEN_ACCESS_CONTROL, 'HTTP_METHOD_FUZZING', 'EXCESSIVE_DATA_EXPOSURE'],
+        attackParamLocations: [AttackParamLocation.HEADER, AttackParamLocation.BODY]
+      })
+      .threshold(Severity.MEDIUM)
+      .timeout(15 * 60 * 1000)
+      .run({
+        method: 'POST',
+        url: `${server.baseUrl}/articles/{slug}/favorite`,
+        headers: { 'Authorization': 'Token jwt.token.here' }
+      })
+  })
+
+  t.end()
+})

--- a/test/sec/post-articles.test.js
+++ b/test/sec/post-articles.test.js
@@ -1,0 +1,51 @@
+'use strict'
+const t = require('tap')
+const startServer = require('../setup-server')
+const { SecRunner, TestType, AttackParamLocation, Severity } = require('@sectester/runner')
+
+let runner
+
+// Increase the timeout for the tests
+jest.setTimeout(15 * 60 * 1000) // 15 minutes
+
+t.test('Security tests for POST /articles', async t => {
+  let server
+
+  t.beforeEach(async () => {
+    server = await startServer()
+    runner = new SecRunner({
+      hostname: process.env.BRIGHT_HOSTNAME
+    })
+    await runner.init()
+  })
+
+  t.teardown(async () => {
+    await runner.clear()
+    await server.close()
+  })
+
+  await runner.createScan({
+    tests: [TestType.JWT, 'csrf', TestType.MASS_ASSIGNMENT, TestType.XSS, TestType.SQLI],
+    attackParamLocations: [AttackParamLocation.BODY, AttackParamLocation.HEADER]
+  })
+  .threshold(Severity.MEDIUM)
+  .timeout(15 * 60 * 1000)
+  .run({
+    method: 'POST',
+    url: `${server.baseUrl}/articles`,
+    headers: {
+      'Authorization': 'Token jwt.token.here',
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify({
+      article: {
+        title: 'string',
+        description: 'string',
+        body: 'string',
+        tagList: ['string']
+      }
+    })
+  })
+
+  t.end()
+})

--- a/test/sec/post-profiles-johndoe-follow.test.js
+++ b/test/sec/post-profiles-johndoe-follow.test.js
@@ -1,0 +1,45 @@
+'use strict'
+const t = require('tap')
+const startServer = require('../setup-server')
+const { SecRunner, TestType, AttackParamLocation, Severity } = require('@sectester/runner')
+
+let runner
+
+// Increase the timeout for the tests
+jest.setTimeout(15 * 60 * 1000) // 15 minutes
+
+t.test('Security tests for POST /api/profiles/johndoe/follow', async t => {
+  let server
+
+  t.beforeEach(async () => {
+    server = await startServer()
+    runner = new SecRunner({
+      hostname: process.env.BRIGHT_HOSTNAME
+    })
+    await runner.init()
+  })
+
+  t.teardown(async () => {
+    await runner.clear()
+    await server.close()
+  })
+
+  t.test('POST /api/profiles/johndoe/follow', async t => {
+    await runner.createScan({
+      tests: [TestType.JWT, TestType.CSRF, TestType.BROKEN_ACCESS_CONTROL, 'EXCESSIVE_DATA_EXPOSURE'],
+      attackParamLocations: [AttackParamLocation.BODY, AttackParamLocation.HEADER]
+    })
+    .threshold(Severity.MEDIUM)
+    .timeout(15 * 60 * 1000)
+    .run({
+      method: 'POST',
+      url: 'http://localhost:3000/api/profiles/johndoe/follow',
+      headers: { 'Authorization': 'Token required_jwt_token' },
+      body: {}
+    })
+
+    t.end()
+  })
+
+  t.end()
+})

--- a/test/sec/post-sentiment-score.test.js
+++ b/test/sec/post-sentiment-score.test.js
@@ -1,0 +1,45 @@
+'use strict'
+const t = require('tap')
+const startServer = require('../setup-server')
+const { SecRunner, TestType, AttackParamLocation, Severity } = require('@sectester/runner')
+
+let runner
+
+// Increase the timeout for the tests
+jest.setTimeout(15 * 60 * 1000) // 15 minutes
+
+t.test('Security tests for POST /sentiment/score', async t => {
+  let server
+
+  t.beforeEach(async () => {
+    server = await startServer()
+    runner = new SecRunner({
+      hostname: process.env.BRIGHT_HOSTNAME
+    })
+    await runner.init()
+  })
+
+  t.teardown(async () => {
+    await runner.clear()
+    await server.close()
+  })
+
+  t.test('POST /sentiment/score', async t => {
+    await runner.createScan({
+      tests: [TestType.JWT, TestType.CSRF, TestType.XSS, TestType.SQLI, 'excessive_data_exposure'],
+      attackParamLocations: [AttackParamLocation.BODY]
+    })
+    .threshold(Severity.MEDIUM)
+    .timeout(15 * 60 * 1000)
+    .run({
+      method: 'POST',
+      url: `${server.baseUrl}/sentiment/score`,
+      headers: { 'Authorization': 'Bearer <token>' },
+      body: { content: '<string>' }
+    })
+
+    t.end()
+  })
+
+  t.end()
+})

--- a/test/sec/put-api-user.test.js
+++ b/test/sec/put-api-user.test.js
@@ -1,0 +1,60 @@
+'use strict'
+const t = require('tap')
+const startServer = require('../setup-server')
+const { SecRunner, TestType } = require('@sectester/runner')
+
+let runner
+
+// Increase the timeout for the tests
+jest.setTimeout(15 * 60 * 1000) // 15 minutes
+
+t.test('Security tests for PUT /api/user', async t => {
+  let server
+
+  t.beforeEach(async () => {
+    server = await startServer()
+    runner = new SecRunner({
+      hostname: process.env.BRIGHT_HOSTNAME
+    })
+    await runner.init()
+  })
+
+  t.teardown(async () => {
+    await runner.clear()
+    await server.close()
+  })
+
+  t.test('PUT /api/user', async t => {
+    await runner.createScan({
+      tests: [
+        TestType.BROKEN_ACCESS_CONTROL,
+        TestType.CSRF,
+        TestType.EXCESSIVE_DATA_EXPOSURE,
+        TestType.MASS_ASSIGNMENT,
+        TestType.SQLI,
+        TestType.XSS
+      ],
+      attackParamLocations: ['BODY', 'HEADER']
+    })
+    .threshold('MEDIUM')
+    .timeout(15 * 60 * 1000)
+    .run({
+      method: 'PUT',
+      url: 'http://localhost:3000/api/user',
+      headers: {
+        'Authorization': 'Bearer <token>',
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({
+        user: {
+          email: 'updated@example.com',
+          password: 'newpassword123'
+        }
+      })
+    })
+
+    t.end()
+  })
+
+  t.end()
+})

--- a/test/sec/put-articles-slug.test.js
+++ b/test/sec/put-articles-slug.test.js
@@ -1,0 +1,56 @@
+'use strict'
+const t = require('tap')
+const startServer = require('../setup-server')
+const { SecRunner, TestType, AttackParamLocation, Severity } = require('@sectester/runner')
+
+let runner
+
+// Increase the timeout for the tests
+jest.setTimeout(15 * 60 * 1000) // 15 minutes
+
+t.test('PUT /articles/{slug}', async t => {
+  let server
+
+  t.beforeEach(async () => {
+    server = await startServer()
+    runner = new SecRunner({
+      hostname: process.env.BRIGHT_HOSTNAME
+    })
+    await runner.init()
+  })
+
+  t.teardown(async () => {
+    await runner.clear()
+    await server.close()
+  })
+
+  t.test('Security tests', async t => {
+    await runner.createScan({
+      tests: [TestType.JWT, TestType.CSRF, TestType.MASS_ASSIGNMENT, TestType.XSS, TestType.SQLI],
+      attackParamLocations: [AttackParamLocation.BODY, AttackParamLocation.HEADER]
+    })
+    .threshold(Severity.MEDIUM)
+    .timeout(15 * 60 * 1000)
+    .run({
+      method: 'PUT',
+      url: `${server.baseUrl}/articles/{slug}`,
+      headers: {
+        'Authorization': 'Token jwt.token.here'
+      },
+      body: {
+        mimeType: 'application/json',
+        text: JSON.stringify({
+          article: {
+            title: 'string',
+            description: 'string',
+            body: 'string'
+          }
+        })
+      }
+    })
+
+    t.end()
+  })
+
+  t.end()
+})


### PR DESCRIPTION
## Description

Adds security tests for the following endpoints:
- GET /articles
- GET /articles/feed
- GET /articles/{slug}
- POST /articles
- PUT /articles/{slug}
- DELETE /articles/{slug}
- POST /articles/{slug}/favorite
- DELETE /articles/{slug}/favorite
- GET /articles/example-slug/comments
- POST /articles/example-slug/comments
- DELETE /articles/example-slug/comments/123
- GET http://localhost:3000/api/profiles/johndoe
- POST http://localhost:3000/api/profiles/johndoe/follow
- DELETE http://localhost:3000/api/profiles/johndoe/follow
- POST /sentiment/score
- GET http://example.com/tags
- POST http://localhost:3000/api/users/login
- POST http://localhost:3000/api/users
- GET http://localhost:3000/api/user
- PUT http://localhost:3000/api/user

Tests cover:
- SQL injection
- XSS vulnerabilities
- Authentication bypass

## Test Plan

- Validate security tests by running the test suite and ensuring all tests pass.

## Endpoints Tested

- GET /articles
- GET /articles/feed
- GET /articles/{slug}
- POST /articles
- PUT /articles/{slug}
- DELETE /articles/{slug}
- POST /articles/{slug}/favorite
- DELETE /articles/{slug}/favorite
- GET /articles/example-slug/comments
- POST /articles/example-slug/comments
- DELETE /articles/example-slug/comments/123
- GET http://localhost:3000/api/profiles/johndoe
- POST http://localhost:3000/api/profiles/johndoe/follow
- DELETE http://localhost:3000/api/profiles/johndoe/follow
- POST /sentiment/score
- GET http://example.com/tags
- POST http://localhost:3000/api/users/login
- POST http://localhost:3000/api/users
- GET http://localhost:3000/api/user
- PUT http://localhost:3000/api/user