### PR TITLE
test(security): add security tests for article and profile endpoints

### DIFF
--- a/.github/workflows/bright.yml
+++ b/.github/workflows/bright.yml
@@ -1,0 +1,29 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - '**'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    env:
+      BRIGHT_HOSTNAME: ${{ vars.BRIGHT_HOSTNAME }}
+      BRIGHT_TOKEN: ${{ secrets.BRIGHT_TOKEN }}
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
+    - name: Set up Node.js
+      uses: actions/setup-node@v2
+      with:
+        node-version: '14'
+
+    - name: Install dependencies
+      run: npm install
+
+    - name: Run tests
+      run: npm test -- test/sec/*

--- a/test/sec/delete-articles-example-article-comments-1.test.js
+++ b/test/sec/delete-articles-example-article-comments-1.test.js
@@ -1,0 +1,40 @@
+'use strict'
+const t = require('tap')
+const startServer = require('../setup-server')
+const { SecRunner, TestType, AttackParamLocation, Severity } = require('@sectester/runner')
+
+let runner
+
+// Increase the timeout for the tests
+jest.setTimeout(15 * 60 * 1000) // 15 minutes
+
+t.test('DELETE /articles/example-article/comments/1', async t => {
+  let server
+
+  t.beforeEach(async () => {
+    server = await startServer()
+    runner = new SecRunner({
+      hostname: process.env.BRIGHT_HOSTNAME
+    })
+    await runner.init()
+  })
+
+  t.teardown(async () => {
+    await runner.clear()
+    await server.close()
+  })
+
+  await runner.createScan({
+    tests: [TestType.BROKEN_ACCESS_CONTROL, TestType.JWT, 'id_enumeration'],
+    attackParamLocations: [AttackParamLocation.PATH]
+  })
+  .threshold(Severity.MEDIUM)
+  .timeout(15 * 60 * 1000)
+  .run({
+    method: 'DELETE',
+    url: 'http://localhost:3000/articles/example-article/comments/1',
+    headers: { 'Authorization': 'Token required_jwt_token' }
+  })
+
+  t.end()
+})

--- a/test/sec/delete-articles-slug-favorite.test.js
+++ b/test/sec/delete-articles-slug-favorite.test.js
@@ -1,0 +1,40 @@
+'use strict'
+const t = require('tap')
+const startServer = require('../setup-server')
+const { SecRunner, TestType, AttackParamLocation, Severity } = require('@sectester/runner')
+
+let runner
+
+// Increase the timeout for the tests
+jest.setTimeout(15 * 60 * 1000) // 15 minutes
+
+t.test('DELETE /articles/:slug/favorite', async t => {
+  let server
+
+  t.beforeEach(async () => {
+    server = await startServer()
+    runner = new SecRunner({
+      hostname: process.env.BRIGHT_HOSTNAME
+    })
+    await runner.init()
+  })
+
+  t.teardown(async () => {
+    await runner.clear()
+    await server.close()
+  })
+
+  await runner.createScan({
+    tests: [TestType.JWT, TestType.BROKEN_ACCESS_CONTROL, 'CSRF', TestType.HTTP_METHOD_FUZZING],
+    attackParamLocations: [AttackParamLocation.HEADER, AttackParamLocation.PATH]
+  })
+  .threshold(Severity.MEDIUM)
+  .timeout(15 * 60 * 1000)
+  .run({
+    method: 'DELETE',
+    url: `${server.baseUrl}/articles/:slug/favorite`,
+    headers: { 'Authorization': 'Token jwt.token.here' }
+  })
+
+  t.end()
+})

--- a/test/sec/delete-articles-slug.test.js
+++ b/test/sec/delete-articles-slug.test.js
@@ -1,0 +1,44 @@
+'use strict'
+const t = require('tap')
+const startServer = require('../setup-server')
+const { SecRunner, TestType, AttackParamLocation, Severity } = require('@sectester/runner')
+
+let runner
+
+// Increase the timeout for the tests
+jest.setTimeout(15 * 60 * 1000) // 15 minutes
+
+t.test('DELETE /articles/:slug', async t => {
+  let server
+
+  t.beforeEach(async () => {
+    server = await startServer()
+    runner = new SecRunner({
+      hostname: process.env.BRIGHT_HOSTNAME
+    })
+    await runner.init()
+  })
+
+  t.teardown(async () => {
+    await runner.clear()
+    await server.close()
+  })
+
+  t.test('Security tests', async t => {
+    await runner.createScan({
+      tests: [TestType.BROKEN_ACCESS_CONTROL, TestType.JWT, 'csrf', TestType.SQLI],
+      attackParamLocations: [AttackParamLocation.HEADER, AttackParamLocation.PATH]
+    })
+    .threshold(Severity.MEDIUM)
+    .timeout(15 * 60 * 1000)
+    .run({
+      method: 'DELETE',
+      url: `${server.baseUrl}/articles/:slug`,
+      headers: { 'Authorization': 'Token jwt.token.here' }
+    })
+
+    t.end()
+  })
+
+  t.end()
+})

--- a/test/sec/delete-profiles-johndoe-follow.test.js
+++ b/test/sec/delete-profiles-johndoe-follow.test.js
@@ -1,0 +1,46 @@
+'use strict'
+const t = require('tap')
+const startServer = require('../setup-server')
+const { SecRunner, TestType, AttackParamLocation, Severity } = require('@sectester/runner')
+
+let runner
+
+// Increase the timeout for the tests
+jest.setTimeout(15 * 60 * 1000) // 15 minutes
+
+t.test('DELETE /profiles/johndoe/follow', async t => {
+  let server
+
+  t.beforeEach(async () => {
+    server = await startServer()
+    runner = new SecRunner({
+      hostname: process.env.BRIGHT_HOSTNAME
+    })
+    await runner.init()
+  })
+
+  t.teardown(async () => {
+    await runner.clear()
+    await server.close()
+  })
+
+  t.test('Security tests', async t => {
+    await runner.createScan({
+      tests: [TestType.JWT, TestType.BROKEN_ACCESS_CONTROL, 'csrf'],
+      attackParamLocations: [AttackParamLocation.HEADER, AttackParamLocation.BODY]
+    })
+    .threshold(Severity.MEDIUM)
+    .timeout(15 * 60 * 1000)
+    .run({
+      method: 'DELETE',
+      url: `${server.baseUrl}/profiles/johndoe/follow`,
+      headers: {
+        Authorization: 'Token required_jwt_token'
+      }
+    })
+
+    t.end()
+  })
+
+  t.end()
+})

--- a/test/sec/get-api-user.test.js
+++ b/test/sec/get-api-user.test.js
@@ -1,0 +1,44 @@
+'use strict'
+const t = require('tap')
+const startServer = require('../setup-server')
+const { SecRunner, TestType, AttackParamLocation, Severity } = require('@sectester/runner')
+
+let runner
+
+// Increase the timeout for the tests
+jest.setTimeout(15 * 60 * 1000) // 15 minutes
+
+t.test('Security tests for GET /api/user', async t => {
+  let server
+
+  t.beforeEach(async () => {
+    server = await startServer()
+    runner = new SecRunner({
+      hostname: process.env.BRIGHT_HOSTNAME
+    })
+    await runner.init()
+  })
+
+  t.teardown(async () => {
+    await runner.clear()
+    await server.close()
+  })
+
+  t.test('GET /api/user', async t => {
+    await runner.createScan({
+      tests: [TestType.BROKEN_ACCESS_CONTROL, TestType.JWT, 'EXCESSIVE_DATA_EXPOSURE'],
+      attackParamLocations: [AttackParamLocation.HEADER]
+    })
+    .threshold(Severity.MEDIUM)
+    .timeout(15 * 60 * 1000)
+    .run({
+      method: 'GET',
+      url: 'http://localhost:3000/api/user',
+      headers: { 'Authorization': 'Bearer <token>' }
+    })
+
+    t.end()
+  })
+
+  t.end()
+})

--- a/test/sec/get-articles-example-article-comments.test.js
+++ b/test/sec/get-articles-example-article-comments.test.js
@@ -1,0 +1,44 @@
+'use strict'
+const t = require('tap')
+const startServer = require('../setup-server')
+const { SecRunner, TestType, AttackParamLocation, Severity } = require('@sectester/runner')
+
+let runner
+
+// Increase the timeout for the tests
+jest.setTimeout(15 * 60 * 1000) // 15 minutes
+
+t.test('Security tests for GET /articles/example-article/comments', async t => {
+  let server
+
+  t.beforeEach(async () => {
+    server = await startServer()
+    runner = new SecRunner({
+      hostname: process.env.BRIGHT_HOSTNAME
+    })
+    await runner.init()
+  })
+
+  t.teardown(async () => {
+    await runner.clear()
+    await server.close()
+  })
+
+  t.test('GET /articles/example-article/comments', async t => {
+    await runner.createScan({
+      tests: [TestType.JWT, 'excessive_data_exposure', 'broken_access_control'],
+      attackParamLocations: [AttackParamLocation.HEADER, AttackParamLocation.PATH]
+    })
+    .threshold(Severity.MEDIUM)
+    .timeout(15 * 60 * 1000)
+    .run({
+      method: 'GET',
+      url: 'http://localhost:3000/articles/example-article/comments',
+      headers: { 'Authorization': 'Token optional_jwt_token' }
+    })
+
+    t.end()
+  })
+
+  t.end()
+})

--- a/test/sec/get-articles-feed.test.js
+++ b/test/sec/get-articles-feed.test.js
@@ -1,0 +1,45 @@
+'use strict'
+const t = require('tap')
+const startServer = require('../setup-server')
+const { SecRunner, TestType, AttackParamLocation, Severity } = require('@sectester/runner')
+
+let runner
+
+// Increase the timeout for the tests
+jest.setTimeout(15 * 60 * 1000) // 15 minutes
+
+t.test('Security tests for GET /articles/feed', async t => {
+  let server
+
+  t.beforeEach(async () => {
+    server = await startServer()
+    runner = new SecRunner({
+      hostname: process.env.BRIGHT_HOSTNAME
+    })
+    await runner.init()
+  })
+
+  t.teardown(async () => {
+    await runner.clear()
+    await server.close()
+  })
+
+  t.test('GET /articles/feed', async t => {
+    await runner.createScan({
+      tests: [TestType.JWT, 'excessive_data_exposure', 'broken_access_control', TestType.HTTP_METHOD_FUZZING],
+      attackParamLocations: [AttackParamLocation.QUERY]
+    })
+    .threshold(Severity.MEDIUM)
+    .timeout(15 * 60 * 1000)
+    .run({
+      method: 'GET',
+      url: '/articles/feed',
+      headers: { 'Authorization': 'Token jwt.token.here' },
+      queryString: { limit: 'number', offset: 'number' }
+    })
+
+    t.end()
+  })
+
+  t.end()
+})

--- a/test/sec/get-articles-slug.test.js
+++ b/test/sec/get-articles-slug.test.js
@@ -1,0 +1,48 @@
+'use strict'
+const t = require('tap')
+const startServer = require('../setup-server')
+const { SecRunner, TestType, AttackParamLocation, Severity } = require('@sectester/runner')
+
+let runner
+
+// Increase the timeout for the tests
+jest.setTimeout(15 * 60 * 1000) // 15 minutes
+
+t.test('Security tests for GET /articles/:slug', async t => {
+  let server
+
+  t.beforeEach(async () => {
+    server = await startServer()
+    runner = new SecRunner({
+      hostname: process.env.BRIGHT_HOSTNAME
+    })
+    await runner.init()
+  })
+
+  t.teardown(async () => {
+    await runner.clear()
+    await server.close()
+  })
+
+  t.test('GET /articles/:slug', async t => {
+    await runner.createScan({
+      tests: [
+        TestType.BROKEN_ACCESS_CONTROL,
+        TestType.EXCESSIVE_DATA_EXPOSURE,
+        'id_enumeration',
+        TestType.XSS
+      ],
+      attackParamLocations: [AttackParamLocation.PATH]
+    })
+    .threshold(Severity.MEDIUM)
+    .timeout(15 * 60 * 1000)
+    .run({
+      method: 'GET',
+      url: `${server.baseUrl}/articles/test-slug`
+    })
+
+    t.end()
+  })
+
+  t.end()
+})

--- a/test/sec/get-articles.test.js
+++ b/test/sec/get-articles.test.js
@@ -1,0 +1,49 @@
+'use strict'
+const t = require('tap')
+const startServer = require('../setup-server')
+const { SecRunner, TestType } = require('@sectester/runner')
+
+let runner
+
+// Increase the timeout for the tests
+jest.setTimeout(15 * 60 * 1000) // 15 minutes
+
+t.test('Security tests for GET /articles', async t => {
+  let server
+
+  t.beforeEach(async () => {
+    server = await startServer()
+    runner = new SecRunner({
+      hostname: process.env.BRIGHT_HOSTNAME
+    })
+    await runner.init()
+  })
+
+  t.teardown(async () => {
+    await runner.clear()
+    await server.close()
+  })
+
+  t.test('GET /articles', async t => {
+    await runner.createScan({
+      tests: [TestType.SQLI, TestType.XSS, 'excessive_data_exposure', 'http_method_fuzzing', 'mass_assignment'],
+      attackParamLocations: ['query']
+    })
+    .threshold('medium')
+    .timeout(15 * 60 * 1000)
+    .run({
+      method: 'GET',
+      url: '/articles',
+      query: {
+        tag: 'string',
+        author: 'string',
+        favorited: 'string',
+        limit: 10,
+        offset: 0
+      }
+    })
+    t.end()
+  })
+
+  t.end()
+})

--- a/test/sec/get-profiles-johndoe.test.js
+++ b/test/sec/get-profiles-johndoe.test.js
@@ -1,0 +1,45 @@
+'use strict'
+const t = require('tap')
+const startServer = require('../setup-server')
+const { SecRunner, TestType, AttackParamLocation, Severity } = require('@sectester/runner')
+
+let runner
+
+// Increase the timeout for the tests
+jest.setTimeout(15 * 60 * 1000) // 15 minutes
+
+t.test('Security tests for GET /profiles/johndoe', async t => {
+  let server
+
+  t.beforeEach(async () => {
+    server = await startServer()
+    runner = new SecRunner({
+      hostname: process.env.BRIGHT_HOSTNAME
+    })
+    await runner.init()
+  })
+
+  t.teardown(async () => {
+    await runner.clear()
+    await server.close()
+  })
+
+  t.test('GET /profiles/johndoe', async t => {
+    await runner
+      .createScan({
+        tests: [TestType.BROKEN_ACCESS_CONTROL, TestType.JWT, 'EXCESSIVE_DATA_EXPOSURE'],
+        attackParamLocations: [AttackParamLocation.HEADER, AttackParamLocation.PATH]
+      })
+      .threshold(Severity.MEDIUM)
+      .timeout(15 * 60 * 1000)
+      .run({
+        method: 'GET',
+        url: '/profiles/johndoe',
+        headers: { 'Authorization': 'Token optional_jwt_token' }
+      })
+
+    t.end()
+  })
+
+  t.end()
+})

--- a/test/sec/get-tags.js
+++ b/test/sec/get-tags.js
@@ -1,0 +1,43 @@
+'use strict'
+const t = require('tap')
+const startServer = require('../setup-server')
+const { SecRunner, TestType } = require('@sectester/runner')
+
+let runner
+
+// Increase the timeout for the tests
+jest.setTimeout(15 * 60 * 1000) // 15 minutes
+
+t.test('Security tests for GET /api/tags', async t => {
+  let server
+
+  t.beforeEach(async () => {
+    server = await startServer()
+    runner = new SecRunner({
+      hostname: process.env.BRIGHT_HOSTNAME
+    })
+    await runner.init()
+  })
+
+  t.teardown(async () => {
+    await runner.clear()
+    await server.close()
+  })
+
+  t.test('Excessive Data Exposure and HTTP Method Fuzzing', async t => {
+    await runner.createScan({
+      tests: [TestType.EXCESSIVE_DATA_EXPOSURE, 'HTTP_METHOD_FUZZING'],
+      attackParamLocations: []
+    })
+    .threshold('MEDIUM')
+    .timeout(15 * 60 * 1000)
+    .run({
+      method: 'GET',
+      url: `${server.baseUrl}/api/tags`
+    })
+
+    t.end()
+  })
+
+  t.end()
+})

--- a/test/sec/post-api-users-login.test.js
+++ b/test/sec/post-api-users-login.test.js
@@ -1,0 +1,58 @@
+'use strict'
+const t = require('tap')
+const startServer = require('../setup-server')
+const { SecRunner, TestType } = require('@sectester/runner')
+
+let runner
+
+// Increase the timeout for the tests
+jest.setTimeout(15 * 60 * 1000) // 15 minutes
+
+t.test('Security tests for POST /api/users/login', async t => {
+  let server
+
+  t.beforeEach(async () => {
+    server = await startServer()
+    runner = new SecRunner({
+      hostname: process.env.BRIGHT_HOSTNAME
+    })
+    await runner.init()
+  })
+
+  t.teardown(async () => {
+    await runner.clear()
+    await server.close()
+  })
+
+  t.test('Run security tests', async t => {
+    await runner.createScan({
+      tests: [
+        TestType.BRUTE_FORCE_LOGIN,
+        TestType.CSRF,
+        TestType.SQLI,
+        TestType.XSS,
+        'insecure_output_handling'
+      ],
+      attackParamLocations: ['body']
+    })
+    .threshold('medium')
+    .timeout(15 * 60 * 1000)
+    .run({
+      method: 'POST',
+      url: 'http://localhost:3000/api/users/login',
+      headers: {
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({
+        user: {
+          email: 'user@example.com',
+          password: 'password123'
+        }
+      })
+    })
+
+    t.end()
+  })
+
+  t.end()
+})

--- a/test/sec/post-api-users.test.js
+++ b/test/sec/post-api-users.test.js
@@ -1,0 +1,60 @@
+'use strict'
+const t = require('tap')
+const startServer = require('../setup-server')
+const { SecRunner, TestType } = require('@sectester/runner')
+
+let runner
+
+// Increase the timeout for the tests
+jest.setTimeout(15 * 60 * 1000) // 15 minutes
+
+t.test('Security tests for POST /api/users', async t => {
+  let server
+
+  t.beforeEach(async () => {
+    server = await startServer()
+    runner = new SecRunner({
+      hostname: process.env.BRIGHT_HOSTNAME
+    })
+    await runner.init()
+  })
+
+  t.teardown(async () => {
+    await runner.clear()
+    await server.close()
+  })
+
+  t.test('POST /api/users', async t => {
+    await runner.createScan({
+      tests: [
+        TestType.CSRF,
+        TestType.BRUTE_FORCE_LOGIN,
+        TestType.MASS_ASSIGNMENT,
+        TestType.SQLI,
+        TestType.XSS,
+        'EMAIL_INJECTION'
+      ],
+      attackParamLocations: ['BODY']
+    })
+    .threshold('MEDIUM')
+    .timeout(15 * 60 * 1000)
+    .run({
+      method: 'POST',
+      url: 'http://localhost:3000/api/users',
+      headers: {
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({
+        user: {
+          username: 'newuser',
+          email: 'newuser@example.com',
+          password: 'password123'
+        }
+      })
+    })
+
+    t.end()
+  })
+
+  t.end()
+})

--- a/test/sec/post-articles-example-article-comments.test.js
+++ b/test/sec/post-articles-example-article-comments.test.js
@@ -1,0 +1,59 @@
+'use strict'
+const t = require('tap')
+const startServer = require('../setup-server')
+const { SecRunner, TestType, AttackParamLocation, Severity } = require('@sectester/runner')
+
+let runner
+
+// Increase the timeout for the tests
+jest.setTimeout(15 * 60 * 1000) // 15 minutes
+
+t.test('Security tests for POST /articles/example-article/comments', async t => {
+  let server
+
+  t.beforeEach(async () => {
+    server = await startServer()
+    runner = new SecRunner({
+      hostname: process.env.BRIGHT_HOSTNAME
+    })
+    await runner.init()
+  })
+
+  t.teardown(async () => {
+    await runner.clear()
+    await server.close()
+  })
+
+  t.test('POST /articles/example-article/comments', async t => {
+    await runner.createScan({
+      tests: [
+        TestType.JWT,
+        TestType.CSRF,
+        TestType.XSS,
+        TestType.SQLI,
+        'excessive_data_exposure',
+        'broken_access_control'
+      ],
+      attackParamLocations: [AttackParamLocation.BODY, AttackParamLocation.HEADER]
+    })
+    .threshold(Severity.MEDIUM)
+    .timeout(15 * 60 * 1000)
+    .run({
+      method: 'POST',
+      url: 'http://localhost:3000/articles/example-article/comments',
+      headers: {
+        'Authorization': 'Token required_jwt_token',
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({
+        comment: {
+          body: 'This is a comment.'
+        }
+      })
+    })
+
+    t.end()
+  })
+
+  t.end()
+})

--- a/test/sec/post-articles-slug-favorite.test.js
+++ b/test/sec/post-articles-slug-favorite.test.js
@@ -1,0 +1,45 @@
+'use strict'
+const t = require('tap')
+const startServer = require('../setup-server')
+const { SecRunner, TestType, AttackParamLocation, Severity } = require('@sectester/runner')
+
+let runner
+
+// Increase the timeout for the tests
+jest.setTimeout(15 * 60 * 1000) // 15 minutes
+
+t.test('Security tests for POST /articles/:slug/favorite', async t => {
+  let server
+
+  t.beforeEach(async () => {
+    server = await startServer()
+    runner = new SecRunner({
+      hostname: process.env.BRIGHT_HOSTNAME
+    })
+    await runner.init()
+  })
+
+  t.teardown(async () => {
+    await runner.clear()
+    await server.close()
+  })
+
+  t.test('POST /articles/:slug/favorite', async t => {
+    await runner.createScan({
+      tests: [TestType.JWT, 'csrf', TestType.BROKEN_ACCESS_CONTROL, 'http_method_fuzzing', TestType.XSS],
+      attackParamLocations: [AttackParamLocation.BODY, AttackParamLocation.HEADER]
+    })
+    .threshold(Severity.MEDIUM)
+    .timeout(15 * 60 * 1000)
+    .run({
+      method: 'POST',
+      url: `${server.baseUrl}/articles/:slug/favorite`,
+      headers: { 'Authorization': 'Token jwt.token.here' },
+      body: {}
+    })
+
+    t.end()
+  })
+
+  t.end()
+})

--- a/test/sec/post-articles.test.js
+++ b/test/sec/post-articles.test.js
@@ -1,0 +1,52 @@
+'use strict'
+const t = require('tap')
+const startServer = require('../setup-server')
+const { SecRunner, TestType, AttackParamLocation, Severity } = require('@sectester/runner')
+
+let runner
+
+// Increase the timeout for the tests
+jest.setTimeout(15 * 60 * 1000) // 15 minutes
+
+t.test('Security tests for POST /articles', async t => {
+  let server
+
+  t.beforeEach(async () => {
+    server = await startServer()
+    runner = new SecRunner({
+      hostname: process.env.BRIGHT_HOSTNAME
+    })
+    await runner.init()
+  })
+
+  t.teardown(async () => {
+    await runner.clear()
+    await server.close()
+  })
+
+  t.test('POST /articles', async t => {
+    await runner.createScan({
+      tests: [TestType.JWT, TestType.CSRF, TestType.MASS_ASSIGNMENT, TestType.XSS, TestType.SQLI],
+      attackParamLocations: [AttackParamLocation.BODY, AttackParamLocation.HEADER]
+    })
+    .threshold(Severity.MEDIUM)
+    .timeout(15 * 60 * 1000)
+    .run({
+      method: 'POST',
+      url: `${server.baseUrl}/articles`,
+      headers: { 'Authorization': 'Token jwt.token.here' },
+      body: JSON.stringify({
+        article: {
+          title: 'string',
+          description: 'string',
+          body: 'string',
+          tagList: ['string']
+        }
+      })
+    })
+
+    t.end()
+  })
+
+  t.end()
+})

--- a/test/sec/post-profiles-johndoe-follow.test.js
+++ b/test/sec/post-profiles-johndoe-follow.test.js
@@ -1,0 +1,47 @@
+'use strict'
+const t = require('tap')
+const startServer = require('../setup-server')
+const { SecRunner, TestType, AttackParamLocation, Severity } = require('@sectester/runner')
+
+let runner
+
+// Increase the timeout for the tests
+jest.setTimeout(15 * 60 * 1000) // 15 minutes
+
+t.test('Security tests for POST /profiles/johndoe/follow', async t => {
+  let server
+
+  t.beforeEach(async () => {
+    server = await startServer()
+    runner = new SecRunner({
+      hostname: process.env.BRIGHT_HOSTNAME
+    })
+    await runner.init()
+  })
+
+  t.teardown(async () => {
+    await runner.clear()
+    await server.close()
+  })
+
+  t.test('POST /profiles/johndoe/follow', async t => {
+    await runner.createScan({
+      tests: [TestType.JWT, TestType.CSRF, TestType.BROKEN_ACCESS_CONTROL, 'business_constraint_bypass'],
+      attackParamLocations: [AttackParamLocation.HEADER, AttackParamLocation.BODY]
+    })
+    .threshold(Severity.MEDIUM)
+    .timeout(15 * 60 * 1000)
+    .run({
+      method: 'POST',
+      url: `${server.baseUrl}/profiles/johndoe/follow`,
+      headers: {
+        'Authorization': 'Token required_jwt_token'
+      },
+      body: {}
+    })
+
+    t.end()
+  })
+
+  t.end()
+})

--- a/test/sec/post-sentiment-score.test.js
+++ b/test/sec/post-sentiment-score.test.js
@@ -1,0 +1,45 @@
+'use strict'
+const t = require('tap')
+const startServer = require('../setup-server')
+const { SecRunner, TestType, AttackParamLocation, Severity } = require('@sectester/runner')
+
+let runner
+
+// Increase the timeout for the tests
+jest.setTimeout(15 * 60 * 1000) // 15 minutes
+
+t.test('Security tests for POST /sentiment/score', async t => {
+  let server
+
+  t.beforeEach(async () => {
+    server = await startServer()
+    runner = new SecRunner({
+      hostname: process.env.BRIGHT_HOSTNAME
+    })
+    await runner.init()
+  })
+
+  t.teardown(async () => {
+    await runner.clear()
+    await server.close()
+  })
+
+  t.test('POST /sentiment/score', async t => {
+    await runner.createScan({
+      tests: [TestType.JWT, TestType.CSRF, TestType.EXCESSIVE_DATA_EXPOSURE, TestType.XSS],
+      attackParamLocations: [AttackParamLocation.BODY]
+    })
+    .threshold(Severity.MEDIUM)
+    .timeout(15 * 60 * 1000)
+    .run({
+      method: 'POST',
+      url: `${server.baseUrl}/sentiment/score`,
+      headers: { 'Authorization': 'Bearer <token>' },
+      body: { 'content': '<string>' }
+    })
+
+    t.end()
+  })
+
+  t.end()
+})

--- a/test/sec/put-api-user.test.js
+++ b/test/sec/put-api-user.test.js
@@ -1,0 +1,60 @@
+'use strict'
+const t = require('tap')
+const startServer = require('../setup-server')
+const { SecRunner, TestType } = require('@sectester/runner')
+
+let runner
+
+// Increase the timeout for the tests
+jest.setTimeout(15 * 60 * 1000) // 15 minutes
+
+t.test('Security tests for PUT /api/user', async t => {
+  let server
+
+  t.beforeEach(async () => {
+    server = await startServer()
+    runner = new SecRunner({
+      hostname: process.env.BRIGHT_HOSTNAME
+    })
+    await runner.init()
+  })
+
+  t.teardown(async () => {
+    await runner.clear()
+    await server.close()
+  })
+
+  t.test('PUT /api/user', async t => {
+    await runner.createScan({
+      tests: [
+        TestType.BROKEN_ACCESS_CONTROL,
+        TestType.CSRF,
+        TestType.EXCESSIVE_DATA_EXPOSURE,
+        TestType.MASS_ASSIGNMENT,
+        TestType.SQLI,
+        TestType.XSS
+      ],
+      attackParamLocations: ['BODY', 'HEADER']
+    })
+    .threshold('MEDIUM')
+    .timeout(15 * 60 * 1000)
+    .run({
+      method: 'PUT',
+      url: 'http://localhost:3000/api/user',
+      headers: {
+        'Authorization': 'Bearer <token>',
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({
+        user: {
+          email: 'updateduser@example.com',
+          password: 'newpassword123'
+        }
+      })
+    })
+
+    t.end()
+  })
+
+  t.end()
+})

--- a/test/sec/put-articles-slug.test.js
+++ b/test/sec/put-articles-slug.test.js
@@ -1,0 +1,51 @@
+'use strict'
+const t = require('tap')
+const startServer = require('../setup-server')
+const { SecRunner, TestType, AttackParamLocation, Severity } = require('@sectester/runner')
+
+let runner
+
+// Increase the timeout for the tests
+jest.setTimeout(15 * 60 * 1000) // 15 minutes
+
+t.test('PUT /articles/:slug', async t => {
+  let server
+
+  t.beforeEach(async () => {
+    server = await startServer()
+    runner = new SecRunner({
+      hostname: process.env.BRIGHT_HOSTNAME
+    })
+    await runner.init()
+  })
+
+  t.teardown(async () => {
+    await runner.clear()
+    await server.close()
+  })
+
+  t.test('Security tests', async t => {
+    await runner.createScan({
+      tests: [TestType.JWT, TestType.CSRF, TestType.MASS_ASSIGNMENT, TestType.XSS, TestType.SQLI],
+      attackParamLocations: [AttackParamLocation.BODY, AttackParamLocation.HEADER, AttackParamLocation.PATH]
+    })
+    .threshold(Severity.MEDIUM)
+    .timeout(15 * 60 * 1000)
+    .run({
+      method: 'PUT',
+      url: `${server.baseUrl}/articles/:slug`,
+      headers: { 'Authorization': 'Token jwt.token.here' },
+      body: JSON.stringify({
+        article: {
+          title: 'string',
+          description: 'string',
+          body: 'string'
+        }
+      })
+    })
+
+    t.end()
+  })
+
+  t.end()
+})


### PR DESCRIPTION
## Description

Adds SecTester security tests for the following endpoints:
- GET /articles
- GET /articles/feed
- GET /articles/:slug
- POST /articles
- PUT /articles/:slug
- DELETE /articles/:slug
- POST /articles/:slug/favorite
- DELETE /articles/:slug/favorite
- GET http://localhost:3000/articles/example-article/comments
- POST http://localhost:3000/articles/example-article/comments
- DELETE http://localhost:3000/articles/example-article/comments/1
- GET /profiles/johndoe
- POST /profiles/johndoe/follow
- DELETE /profiles/johndoe/follow
- POST /sentiment/score
- GET http://example.com/api/tags
- POST http://localhost:3000/api/users/login
- POST http://localhost:3000/api/users
- GET http://localhost:3000/api/user
- PUT http://localhost:3000/api/user

Tests cover:
- SQL injection
- XSS vulnerabilities
- Authentication bypass

## Checklist
- [x] Tests implemented
- [x] Documentation updated