### PR TITLE
test(security): add security tests for API endpoints

### DIFF
--- a/.github/workflows/bright.yml
+++ b/.github/workflows/bright.yml
@@ -1,0 +1,42 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - '**'
+
+permissions:
+  checks: write
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    env:
+      BRIGHT_HOSTNAME: ${{ vars.BRIGHT_HOSTNAME }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '16'
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Create .env file
+        run: npm run create:env
+
+      - name: Start application
+        run: npm start &
+        env:
+          PORT: 5000
+
+      - name: Run tests
+        run: npx tap test/security/*.test.js
+        env:
+          BRIGHT_TOKEN: ${{ secrets.BRIGHT_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_COMMIT_SHA: ${{ github.event.pull_request.head.sha }}

--- a/test/security/delete-articles-by-slug-comments-by-id.test.js
+++ b/test/security/delete-articles-by-slug-comments-by-id.test.js
@@ -1,0 +1,48 @@
+const t = require('tap');
+const { SecRunner } = require('@sectester/runner');
+const { TestType, Severity, AttackParamLocation, HttpMethod } = require('@sectester/scan');
+
+let runner;
+let app;
+let baseUrl;
+
+// Setup hooks for initializing the application and SecTester
+
+t.before(async () => {
+  app = require('../../lib/server'); // Adjust the path to the actual server file
+
+  await app.ready();
+
+  baseUrl = app.server.address().port;
+});
+
+t.beforeEach(async () => {
+  runner = new SecRunner({
+    hostname: process.env.BRIGHT_HOSTNAME
+  });
+
+  await runner.init();
+});
+
+t.afterEach(() => runner.clear());
+
+t.after(() => app.close());
+
+// Placeholder for test cases
+
+test('DELETE /api/articles/:slug/comments/:id', async t => {
+  const promise = runner
+    .createScan({
+      tests: [TestType.BROKEN_ACCESS_CONTROL, TestType.JWT, TestType.UNVALIDATED_REDIRECT],
+      attackParamLocations: [AttackParamLocation.PATH]
+    })
+    .threshold(Severity.LOW)
+    .timeout(15 * 60 * 1000)
+    .run({
+      method: HttpMethod.DELETE,
+      url: `${baseUrl}/api/articles/test-slug/comments/1`,
+      headers: { Authorization: 'Token jwt.token.here' }
+    });
+
+  await t.notThrowsAsync(promise);
+});

--- a/test/security/delete-articles-by-slug-favorite.test.js
+++ b/test/security/delete-articles-by-slug-favorite.test.js
@@ -1,0 +1,56 @@
+const t = require('tap');
+const { SecRunner } = require('@sectester/runner');
+const { TestType, Severity, AttackParamLocation, HttpMethod } = require('@sectester/scan');
+
+let runner;
+let app;
+let baseUrl;
+
+// Setup hooks for initializing the application and SecTester
+
+t.before(async () => {
+  app = require('../../lib/server'); // Adjust the path to the actual server file
+
+  await app.ready();
+
+  baseUrl = app.server.address().port;
+});
+
+t.beforeEach(async () => {
+  runner = new SecRunner({
+    hostname: process.env.BRIGHT_HOSTNAME
+  });
+
+  await runner.init();
+});
+
+t.afterEach(() => runner.clear());
+
+t.after(() => app.close());
+
+// Placeholder for test cases
+
+t.test('DELETE /api/articles/:slug/favorite', async t => {
+  const promise = runner
+    .createScan({
+      tests: [
+        TestType.BROKEN_ACCESS_CONTROL,
+        TestType.JWT,
+        TestType.SQLI,
+        TestType.XSS,
+        TestType.CSRF,
+        TestType.UNVALIDATED_REDIRECT,
+        TestType.ID_ENUMERATION
+      ],
+      attackParamLocations: [AttackParamLocation.PATH, AttackParamLocation.HEADER]
+    })
+    .threshold(Severity.LOW)
+    .timeout(15 * 60 * 1000)
+    .run({
+      method: HttpMethod.DELETE,
+      url: `${baseUrl}/api/articles/:slug/favorite`,
+      headers: { Authorization: 'Token jwt.token.here' }
+    });
+
+  await t.notThrow(promise);
+});

--- a/test/security/delete-articles-by-slug.test.js
+++ b/test/security/delete-articles-by-slug.test.js
@@ -1,0 +1,55 @@
+const t = require('tap');
+const { SecRunner } = require('@sectester/runner');
+const { TestType, Severity, AttackParamLocation, HttpMethod } = require('@sectester/scan');
+
+let runner;
+let app;
+let baseUrl;
+
+// Setup hooks for initializing the application and SecTester
+
+t.before(async () => {
+  app = require('../../lib/server'); // Adjust the path to the actual server file
+
+  await app.ready();
+
+  baseUrl = app.server.address().port;
+});
+
+t.beforeEach(async () => {
+  runner = new SecRunner({
+    hostname: process.env.BRIGHT_HOSTNAME
+  });
+
+  await runner.init();
+});
+
+t.afterEach(() => runner.clear());
+
+t.after(() => app.close());
+
+// Placeholder for test cases
+
+test('DELETE /api/articles/:slug', async t => {
+  const promise = runner
+    .createScan({
+      tests: [
+        TestType.BROKEN_ACCESS_CONTROL,
+        TestType.SQLI,
+        TestType.XSS,
+        TestType.CSRF,
+        TestType.INSECURE_OUTPUT_HANDLING,
+        TestType.ID_ENUMERATION
+      ],
+      attackParamLocations: [AttackParamLocation.PATH, AttackParamLocation.HEADER]
+    })
+    .threshold(Severity.LOW)
+    .timeout(15 * 60 * 1000)
+    .run({
+      method: HttpMethod.DELETE,
+      url: `${baseUrl}/api/articles/test-slug`,
+      headers: { Authorization: 'Token jwt.token.here' }
+    });
+
+  await t.notThrowsAsync(promise);
+});

--- a/test/security/delete-profiles-username-follow.test.js
+++ b/test/security/delete-profiles-username-follow.test.js
@@ -1,0 +1,55 @@
+const t = require('tap');
+const { SecRunner } = require('@sectester/runner');
+const { TestType, Severity, AttackParamLocation, HttpMethod } = require('@sectester/scan');
+
+let runner;
+let app;
+let baseUrl;
+
+// Setup hooks for initializing the application and SecTester
+
+t.before(async () => {
+  app = require('../../lib/server'); // Adjust the path to the actual server file
+
+  await app.ready();
+
+  baseUrl = app.server.address().port;
+});
+
+t.beforeEach(async () => {
+  runner = new SecRunner({
+    hostname: process.env.BRIGHT_HOSTNAME
+  });
+
+  await runner.init();
+});
+
+t.afterEach(() => runner.clear());
+
+t.after(() => app.close());
+
+// Placeholder for test cases
+
+test('DELETE /api/profiles/:username/follow', async t => {
+  const promise = runner
+    .createScan({
+      tests: [
+        TestType.BROKEN_ACCESS_CONTROL,
+        TestType.CSRF,
+        TestType.SQLI,
+        TestType.XSS,
+        TestType.ID_ENUMERATION,
+        TestType.JWT
+      ],
+      attackParamLocations: [AttackParamLocation.PATH, AttackParamLocation.HEADER]
+    })
+    .threshold(Severity.LOW)
+    .timeout(15 * 60 * 1000)
+    .run({
+      method: HttpMethod.DELETE,
+      url: `${baseUrl}/api/profiles/:username/follow`,
+      headers: { Authorization: 'Token jwt.token.here' }
+    });
+
+  await t.notThrowsAsync(promise);
+});

--- a/test/security/get-articles-by-slug.test.js
+++ b/test/security/get-articles-by-slug.test.js
@@ -1,0 +1,53 @@
+const t = require('tap');
+const { SecRunner } = require('@sectester/runner');
+const startServer = require('../setup-server');
+
+let runner;
+let app;
+let baseUrl;
+
+// Setup hooks for initializing the application and SecTester
+
+t.before(async () => {
+  app = await startServer();
+
+  await app.ready();
+
+  baseUrl = app.server.address().port;
+});
+
+t.beforeEach(async () => {
+  runner = new SecRunner({
+    hostname: process.env.BRIGHT_HOSTNAME
+  });
+
+  await runner.init();
+});
+
+t.afterEach(() => runner.clear());
+
+t.after(() => app.close());
+
+// Placeholder for test cases
+
+test('GET /api/articles/:slug', async t => {
+  const promise = runner
+    .createScan({
+      tests: [
+        'sqli',
+        'xss',
+        'excessive_data_exposure',
+        'id_enumeration',
+        'full_path_disclosure'
+      ],
+      attackParamLocations: ['path']
+    })
+    .threshold('low')
+    .timeout(15 * 60 * 1000)
+    .run({
+      method: 'GET',
+      url: `${baseUrl}/api/articles/test-slug`
+    });
+
+  await t.notThrowsAsync(promise);
+});

--- a/test/security/get-articles-feed.test.js
+++ b/test/security/get-articles-feed.test.js
@@ -1,0 +1,59 @@
+const t = require('tap');
+const { SecRunner } = require('@sectester/runner');
+const { TestType, Severity, AttackParamLocation, HttpMethod } = require('@sectester/scan');
+
+let runner;
+let app;
+let baseUrl;
+
+// Setup hooks for initializing the application and SecTester
+
+t.before(async () => {
+  app = require('../../lib/server'); // Adjust the path to the actual server file
+
+  await app.ready();
+
+  baseUrl = app.server.address().port;
+});
+
+t.beforeEach(async () => {
+  runner = new SecRunner({
+    hostname: process.env.BRIGHT_HOSTNAME
+  });
+
+  await runner.init();
+});
+
+t.afterEach(() => runner.clear());
+
+t.after(() => app.close());
+
+// Placeholder for test cases
+
+t.test('GET /api/articles/feed', async t => {
+  const promise = runner
+    .createScan({
+      tests: [
+        TestType.JWT,
+        TestType.EXCESSIVE_DATA_EXPOSURE,
+        TestType.ID_ENUMERATION,
+        TestType.SQLI,
+        TestType.XSS,
+        TestType.CSRF,
+        TestType.INSECURE_OUTPUT_HANDLING,
+        TestType.MASS_ASSIGNMENT,
+        TestType.UNVALIDATED_REDIRECT
+      ],
+      attackParamLocations: [AttackParamLocation.QUERY, AttackParamLocation.HEADER]
+    })
+    .threshold(Severity.LOW)
+    .timeout(15 * 60 * 1000)
+    .run({
+      method: HttpMethod.GET,
+      url: `${baseUrl}/api/articles/feed`,
+      headers: { Authorization: 'Token jwt.token.here' },
+      query: { limit: '20', offset: '0' }
+    });
+
+  await t.notThrow(promise);
+});

--- a/test/security/get-articles-slug-comments.test.js
+++ b/test/security/get-articles-slug-comments.test.js
@@ -1,0 +1,47 @@
+const t = require('tap');
+const { SecRunner } = require('@sectester/runner');
+const { TestType, Severity, AttackParamLocation, HttpMethod } = require('@sectester/scan');
+
+let runner;
+let app;
+let baseUrl;
+
+// Setup hooks for initializing the application and SecTester
+
+t.before(async () => {
+  app = require('../../lib/server'); // Adjust the path to the actual server file
+
+  await app.ready();
+
+  baseUrl = app.server.address().port;
+});
+
+t.beforeEach(async () => {
+  runner = new SecRunner({
+    hostname: process.env.BRIGHT_HOSTNAME
+  });
+
+  await runner.init();
+});
+
+t.afterEach(() => runner.clear());
+
+t.after(() => app.close());
+
+// Placeholder for test cases
+
+t.test('GET /api/articles/:slug/comments', async t => {
+  const promise = runner
+    .createScan({
+      tests: [TestType.SQLI, TestType.XSS, TestType.EXCESSIVE_DATA_EXPOSURE],
+      attackParamLocations: [AttackParamLocation.PATH]
+    })
+    .threshold(Severity.LOW)
+    .timeout(15 * 60 * 1000)
+    .run({
+      method: HttpMethod.GET,
+      url: `${baseUrl}/api/articles/test-slug/comments`
+    });
+
+  await t.notThrow(promise);
+});

--- a/test/security/get-articles.test.js
+++ b/test/security/get-articles.test.js
@@ -1,0 +1,54 @@
+const t = require('tap');
+const { SecRunner } = require('@sectester/runner');
+const { TestType, Severity, AttackParamLocation, HttpMethod } = require('@sectester/scan');
+
+let runner;
+let app;
+let baseUrl;
+
+// Setup hooks for initializing the application and SecTester
+
+t.before(async () => {
+  app = require('../../lib/server'); // Adjust the path to the actual server file
+
+  await app.ready();
+
+  baseUrl = app.server.address().port;
+});
+
+t.beforeEach(async () => {
+  runner = new SecRunner({
+    hostname: process.env.BRIGHT_HOSTNAME
+  });
+
+  await runner.init();
+});
+
+t.afterEach(() => runner.clear());
+
+t.after(() => app.close());
+
+// Placeholder for test cases
+
+test('GET /api/articles', async t => {
+  const promise = runner
+    .createScan({
+      tests: [TestType.SQLI, TestType.XSS, TestType.EXCESSIVE_DATA_EXPOSURE, TestType.ID_ENUMERATION],
+      attackParamLocations: [AttackParamLocation.QUERY]
+    })
+    .threshold(Severity.LOW)
+    .timeout(15 * 60 * 1000)
+    .run({
+      method: HttpMethod.GET,
+      url: `${baseUrl}/api/articles`,
+      query: {
+        tag: 'string',
+        author: 'string',
+        favorited: 'string',
+        limit: '20',
+        offset: '0'
+      }
+    });
+
+  await t.notThrowsAsync(promise);
+});

--- a/test/security/get-profiles-by-username.test.js
+++ b/test/security/get-profiles-by-username.test.js
@@ -1,0 +1,47 @@
+const t = require('tap');
+const { SecRunner } = require('@sectester/runner');
+const { TestType, Severity, AttackParamLocation, HttpMethod } = require('@sectester/scan');
+
+let runner;
+let app;
+let baseUrl;
+
+// Setup hooks for initializing the application and SecTester
+
+t.before(async () => {
+  app = require('../../lib/server'); // Adjust the path to the actual server file
+
+  await app.ready();
+
+  baseUrl = app.server.address().port;
+});
+
+t.beforeEach(async () => {
+  runner = new SecRunner({
+    hostname: process.env.BRIGHT_HOSTNAME
+  });
+
+  await runner.init();
+});
+
+t.afterEach(() => runner.clear());
+
+t.after(() => app.close());
+
+// Placeholder for test cases
+
+t.test('GET /api/profiles/:username', async t => {
+  const promise = runner
+    .createScan({
+      tests: [TestType.SQLI, TestType.EXCESSIVE_DATA_EXPOSURE, TestType.ID_ENUMERATION],
+      attackParamLocations: [AttackParamLocation.PATH]
+    })
+    .threshold(Severity.LOW)
+    .timeout(15 * 60 * 1000)
+    .run({
+      method: HttpMethod.GET,
+      url: `${baseUrl}/api/profiles/testuser`
+    });
+
+  await t.notThrow(promise);
+});

--- a/test/security/get-tags.test.js
+++ b/test/security/get-tags.test.js
@@ -1,0 +1,47 @@
+const t = require('tap');
+const { SecRunner } = require('@sectester/runner');
+const { TestType, Severity, AttackParamLocation, HttpMethod } = require('@sectester/scan');
+
+let runner;
+let app;
+let baseUrl;
+
+// Setup hooks for initializing the application and SecTester
+
+t.before(async () => {
+  app = require('../../lib/server'); // Adjust the path to the actual server file
+
+  await app.ready();
+
+  baseUrl = app.server.address().port;
+});
+
+t.beforeEach(async () => {
+  runner = new SecRunner({
+    hostname: process.env.BRIGHT_HOSTNAME
+  });
+
+  await runner.init();
+});
+
+t.afterEach(() => runner.clear());
+
+t.after(() => app.close());
+
+// Placeholder for test cases
+
+t.test('GET /api/tags', async t => {
+  const promise = runner
+    .createScan({
+      tests: [TestType.SQLI, TestType.EXCESSIVE_DATA_EXPOSURE],
+      attackParamLocations: [AttackParamLocation.QUERY]
+    })
+    .threshold(Severity.LOW)
+    .timeout(15 * 60 * 1000)
+    .run({
+      method: HttpMethod.GET,
+      url: `${baseUrl}/api/tags`
+    });
+
+  await t.notThrow(promise);
+});

--- a/test/security/get-user.test.js
+++ b/test/security/get-user.test.js
@@ -1,0 +1,56 @@
+const t = require('tap');
+const { SecRunner } = require('@sectester/runner');
+const { TestType, Severity, AttackParamLocation, HttpMethod } = require('@sectester/scan');
+
+let runner;
+let app;
+let baseUrl;
+
+// Setup hooks for initializing the application and SecTester
+
+t.before(async () => {
+  app = require('../../lib/server'); // Adjust the path to the actual server file
+
+  await app.ready();
+
+  baseUrl = app.server.address().port;
+});
+
+t.beforeEach(async () => {
+  runner = new SecRunner({
+    hostname: process.env.BRIGHT_HOSTNAME
+  });
+
+  await runner.init();
+});
+
+t.afterEach(() => runner.clear());
+
+t.after(() => app.close());
+
+// Placeholder for test cases
+
+test('GET /api/user', async t => {
+  const promise = runner
+    .createScan({
+      tests: [
+        TestType.JWT,
+        TestType.BROKEN_ACCESS_CONTROL,
+        TestType.SQLI,
+        TestType.XSS,
+        TestType.CSRF,
+        TestType.INSECURE_OUTPUT_HANDLING,
+        TestType.EXCESSIVE_DATA_EXPOSURE
+      ],
+      attackParamLocations: [AttackParamLocation.HEADER]
+    })
+    .threshold(Severity.LOW)
+    .timeout(15 * 60 * 1000)
+    .run({
+      method: HttpMethod.GET,
+      url: `${baseUrl}/api/user`,
+      headers: { Authorization: 'Token jwt.token.here' }
+    });
+
+  await t.notThrowsAsync(promise);
+});

--- a/test/security/post-api-articles.test.js
+++ b/test/security/post-api-articles.test.js
@@ -1,0 +1,70 @@
+const t = require('tap');
+const { SecRunner } = require('@sectester/runner');
+const { TestType, Severity, AttackParamLocation, HttpMethod } = require('@sectester/scan');
+
+let runner;
+let app;
+let baseUrl;
+
+// Setup hooks for initializing the application and SecTester
+
+t.before(async () => {
+  app = require('../../lib/server'); // Adjust the path to the actual server file
+
+  await app.ready();
+
+  baseUrl = app.server.address().port;
+});
+
+t.beforeEach(async () => {
+  runner = new SecRunner({
+    hostname: process.env.BRIGHT_HOSTNAME
+  });
+
+  await runner.init();
+});
+
+t.afterEach(() => runner.clear());
+
+t.after(() => app.close());
+
+// Placeholder for test cases
+
+test('POST /api/articles', async t => {
+  const promise = runner
+    .createScan({
+      tests: [
+        TestType.SQLI,
+        TestType.XSS,
+        TestType.CSRF,
+        TestType.BROKEN_ACCESS_CONTROL,
+        TestType.INSECURE_OUTPUT_HANDLING,
+        TestType.MASS_ASSIGNMENT,
+        TestType.EXCESSIVE_DATA_EXPOSURE,
+        TestType.STORED_XSS,
+        TestType.JWT,
+        TestType.COOKIE_SECURITY
+      ],
+      attackParamLocations: [AttackParamLocation.BODY]
+    })
+    .threshold(Severity.LOW)
+    .timeout(15 * 60 * 1000)
+    .run({
+      method: HttpMethod.POST,
+      url: `${baseUrl}/api/articles`,
+      headers: {
+        'Authorization': 'Token jwt.token.here',
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({
+        article: {
+          title: 'string',
+          description: 'string',
+          body: 'string',
+          tagList: ['string']
+        }
+      })
+    });
+
+  await t.notThrowsAsync(promise);
+});

--- a/test/security/post-api-users-login.test.js
+++ b/test/security/post-api-users-login.test.js
@@ -1,0 +1,70 @@
+const t = require('tap');
+const { SecRunner } = require('@sectester/runner');
+const { TestType, Severity, AttackParamLocation, HttpMethod } = require('@sectester/scan');
+
+let runner;
+let app;
+let baseUrl;
+
+// Setup hooks for initializing the application and SecTester
+
+t.before(async () => {
+  app = require('../../lib/server'); // Adjust the path to the actual server file
+
+  await app.ready();
+
+  baseUrl = app.server.address().port;
+});
+
+t.beforeEach(async () => {
+  runner = new SecRunner({
+    hostname: process.env.BRIGHT_HOSTNAME
+  });
+
+  await runner.init();
+});
+
+t.afterEach(() => runner.clear());
+
+t.after(() => app.close());
+
+// Placeholder for test cases
+
+t.test('POST /api/users/login', async t => {
+  const promise = runner
+    .createScan({
+      tests: [
+        TestType.SQLI,
+        TestType.XSS,
+        TestType.CSRF,
+        TestType.BROKEN_ACCESS_CONTROL,
+        TestType.INSECURE_OUTPUT_HANDLING,
+        TestType.BRUTE_FORCE_LOGIN,
+        TestType.MASS_ASSIGNMENT,
+        TestType.EXCESSIVE_DATA_EXPOSURE,
+        TestType.JWT,
+        TestType.COOKIE_SECURITY
+      ],
+      attackParamLocations: [
+        AttackParamLocation.BODY,
+        AttackParamLocation.HEADER
+      ]
+    })
+    .threshold(Severity.LOW)
+    .timeout(15 * 60 * 1000)
+    .run({
+      method: HttpMethod.POST,
+      url: `${baseUrl}/api/users/login`,
+      headers: {
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({
+        user: {
+          email: 'string',
+          password: 'string'
+        }
+      })
+    });
+
+  await t.resolves(promise);
+});

--- a/test/security/post-articles-by-slug-favorite.test.js
+++ b/test/security/post-articles-by-slug-favorite.test.js
@@ -1,0 +1,60 @@
+const t = require('tap');
+const { SecRunner } = require('@sectester/runner');
+const { TestType, Severity, AttackParamLocation, HttpMethod } = require('@sectester/scan');
+
+let runner;
+let app;
+let baseUrl;
+
+// Setup hooks for initializing the application and SecTester
+
+t.before(async () => {
+  app = require('../../lib/server'); // Adjust the path to the actual server file
+
+  await app.ready();
+
+  baseUrl = app.server.address().port;
+});
+
+t.beforeEach(async () => {
+  runner = new SecRunner({
+    hostname: process.env.BRIGHT_HOSTNAME
+  });
+
+  await runner.init();
+});
+
+t.afterEach(() => runner.clear());
+
+t.after(() => app.close());
+
+// Placeholder for test cases
+
+test('POST /api/articles/:slug/favorite', async t => {
+  const promise = runner
+    .createScan({
+      tests: [
+        TestType.BROKEN_ACCESS_CONTROL,
+        TestType.SQLI,
+        TestType.XSS,
+        TestType.CSRF,
+        TestType.INSECURE_OUTPUT_HANDLING,
+        TestType.ID_ENUMERATION,
+        TestType.UNVALIDATED_REDIRECT,
+        TestType.JWT,
+        TestType.COOKIE_SECURITY,
+        TestType.BRUTE_FORCE_LOGIN,
+        TestType.STORED_XSS
+      ],
+      attackParamLocations: [AttackParamLocation.PATH, AttackParamLocation.HEADER]
+    })
+    .threshold(Severity.LOW)
+    .timeout(15 * 60 * 1000)
+    .run({
+      method: HttpMethod.POST,
+      url: `${baseUrl}/api/articles/:slug/favorite`,
+      headers: { Authorization: 'Token jwt.token.here' }
+    });
+
+  await t.notThrowsAsync(promise);
+});

--- a/test/security/post-articles-slug-comments.test.js
+++ b/test/security/post-articles-slug-comments.test.js
@@ -1,0 +1,65 @@
+const t = require('tap');
+const { SecRunner } = require('@sectester/runner');
+const { TestType, Severity, AttackParamLocation, HttpMethod } = require('@sectester/scan');
+
+let runner;
+let app;
+let baseUrl;
+
+// Setup hooks for initializing the application and SecTester
+
+t.before(async () => {
+  app = require('../../lib/server'); // Adjust the path to the actual server file
+
+  await app.ready();
+
+  baseUrl = app.server.address().port;
+});
+
+t.beforeEach(async () => {
+  runner = new SecRunner({
+    hostname: process.env.BRIGHT_HOSTNAME
+  });
+
+  await runner.init();
+});
+
+t.afterEach(() => runner.clear());
+
+t.after(() => app.close());
+
+// Placeholder for test cases
+
+test('POST /api/articles/:slug/comments', async t => {
+  const promise = runner
+    .createScan({
+      tests: [
+        TestType.XSS,
+        TestType.CSRF,
+        TestType.SQLI,
+        TestType.BROKEN_ACCESS_CONTROL,
+        TestType.INSECURE_OUTPUT_HANDLING,
+        TestType.MASS_ASSIGNMENT,
+        TestType.EXCESSIVE_DATA_EXPOSURE,
+        TestType.STORED_XSS
+      ],
+      attackParamLocations: [AttackParamLocation.BODY, AttackParamLocation.HEADER]
+    })
+    .threshold(Severity.LOW)
+    .timeout(15 * 60 * 1000)
+    .run({
+      method: HttpMethod.POST,
+      url: `${baseUrl}/api/articles/:slug/comments`,
+      headers: {
+        Authorization: 'Token jwt.token.here',
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({
+        comment: {
+          body: 'string'
+        }
+      })
+    });
+
+  await t.notThrowsAsync(promise);
+});

--- a/test/security/post-profiles-username-follow.test.js
+++ b/test/security/post-profiles-username-follow.test.js
@@ -1,0 +1,61 @@
+const t = require('tap');
+const { SecRunner } = require('@sectester/runner');
+const start = require('../setup-server');
+
+let runner;
+let app;
+let baseUrl;
+
+// Setup hooks for initializing the application and SecTester
+
+t.before(async () => {
+  app = await start();
+
+  await app.ready();
+
+  baseUrl = app.server.address().port;
+});
+
+t.beforeEach(async () => {
+  runner = new SecRunner({
+    hostname: process.env.BRIGHT_HOSTNAME
+  });
+
+  await runner.init();
+});
+
+t.afterEach(() => runner.clear());
+
+t.after(() => app.close());
+
+// Placeholder for test cases
+
+test('POST /api/profiles/:username/follow', async t => {
+  const promise = runner
+    .createScan({
+      tests: [
+        'sqli',
+        'xss',
+        'csrf',
+        'broken_access_control',
+        'insecure_output_handling',
+        'mass_assignment',
+        'excessive_data_exposure',
+        'jwt',
+        'cookie_security',
+        'brute_force_login',
+        'stored_xss',
+        'unvalidated_redirect'
+      ],
+      attackParamLocations: ['body', 'header', 'path']
+    })
+    .threshold('LOW')
+    .timeout(15 * 60 * 1000)
+    .run({
+      method: 'POST',
+      url: `${baseUrl}/api/profiles/:username/follow`,
+      headers: { Authorization: 'Token jwt.token.here' }
+    });
+
+  await t.notThrowsAsync(promise);
+});

--- a/test/security/post-sentiment-score.test.js
+++ b/test/security/post-sentiment-score.test.js
@@ -1,0 +1,49 @@
+const t = require('tap');
+const { SecRunner } = require('@sectester/runner');
+const { TestType, Severity, AttackParamLocation, HttpMethod } = require('@sectester/scan');
+
+let runner;
+let app;
+let baseUrl;
+
+// Setup hooks for initializing the application and SecTester
+
+t.before(async () => {
+  app = require('../../lib/server'); // Adjust the path to the actual server file
+
+  await app.ready();
+
+  baseUrl = app.server.address().port;
+});
+
+t.beforeEach(async () => {
+  runner = new SecRunner({
+    hostname: process.env.BRIGHT_HOSTNAME
+  });
+
+  await runner.init();
+});
+
+t.afterEach(() => runner.clear());
+
+t.after(() => app.close());
+
+// Placeholder for test cases
+
+test('POST /api/sentiment/score', async t => {
+  const promise = runner
+    .createScan({
+      tests: [TestType.SQLI, TestType.XSS, TestType.CSRF, TestType.INSECURE_OUTPUT_HANDLING, TestType.EXCESSIVE_DATA_EXPOSURE],
+      attackParamLocations: [AttackParamLocation.BODY]
+    })
+    .threshold(Severity.LOW)
+    .timeout(15 * 60 * 1000)
+    .run({
+      method: HttpMethod.POST,
+      url: `${baseUrl}/api/sentiment/score`,
+      headers: { 'Content-Type': 'application/json' },
+      body: { content: 'string' }
+    });
+
+  await t.notThrowsAsync(promise);
+});

--- a/test/security/post-users.test.js
+++ b/test/security/post-users.test.js
@@ -1,0 +1,67 @@
+const t = require('tap');
+const { SecRunner } = require('@sectester/runner');
+const { TestType, Severity, AttackParamLocation, HttpMethod } = require('@sectester/scan');
+
+let runner;
+let app;
+let baseUrl;
+
+// Setup hooks for initializing the application and SecTester
+
+t.before(async () => {
+  app = require('../../lib/server'); // Adjust the path to the actual server file
+
+  await app.ready();
+
+  baseUrl = app.server.address().port;
+});
+
+t.beforeEach(async () => {
+  runner = new SecRunner({
+    hostname: process.env.BRIGHT_HOSTNAME
+  });
+
+  await runner.init();
+});
+
+t.afterEach(() => runner.clear());
+
+t.after(() => app.close());
+
+// Placeholder for test cases
+
+test('POST /api/users', async t => {
+  const promise = runner
+    .createScan({
+      tests: [
+        TestType.SQLI,
+        TestType.XSS,
+        TestType.CSRF,
+        TestType.BROKEN_ACCESS_CONTROL,
+        TestType.INSECURE_OUTPUT_HANDLING,
+        TestType.MASS_ASSIGNMENT,
+        TestType.EXCESSIVE_DATA_EXPOSURE,
+        TestType.JWT,
+        TestType.COOKIE_SECURITY,
+        TestType.BRUTE_FORCE_LOGIN,
+        TestType.STORED_XSS
+      ],
+      attackParamLocations: [AttackParamLocation.BODY]
+    })
+    .threshold(Severity.LOW)
+    .timeout(15 * 60 * 1000)
+    .run({
+      method: HttpMethod.POST,
+      url: `${baseUrl}/api/users`,
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        user: {
+          username: 'string',
+          email: 'string',
+          password: 'string'
+        }
+      })
+    });
+
+  await t.notThrowsAsync(promise);
+});

--- a/test/security/put-api-user.test.js
+++ b/test/security/put-api-user.test.js
@@ -1,0 +1,72 @@
+const t = require('tap');
+const { SecRunner } = require('@sectester/runner');
+const { TestType, Severity, AttackParamLocation, HttpMethod } = require('@sectester/scan');
+
+let runner;
+let app;
+let baseUrl;
+
+// Setup hooks for initializing the application and SecTester
+
+t.before(async () => {
+  app = require('../../lib/server'); // Adjust the path to the actual server file
+
+  await app.ready();
+
+  baseUrl = app.server.address().port;
+});
+
+t.beforeEach(async () => {
+  runner = new SecRunner({
+    hostname: process.env.BRIGHT_HOSTNAME
+  });
+
+  await runner.init();
+});
+
+t.afterEach(() => runner.clear());
+
+t.after(() => app.close());
+
+// Placeholder for test cases
+
+test('PUT /api/user', async t => {
+  const promise = runner
+    .createScan({
+      tests: [
+        TestType.SQLI,
+        TestType.XSS,
+        TestType.CSRF,
+        TestType.BROKEN_ACCESS_CONTROL,
+        TestType.INSECURE_OUTPUT_HANDLING,
+        TestType.MASS_ASSIGNMENT,
+        TestType.EXCESSIVE_DATA_EXPOSURE,
+        TestType.JWT,
+        TestType.COOKIE_SECURITY,
+        TestType.STORED_XSS,
+        TestType.PASSWORD_RESET_POISONING
+      ],
+      attackParamLocations: [AttackParamLocation.BODY]
+    })
+    .threshold(Severity.LOW)
+    .timeout(15 * 60 * 1000)
+    .run({
+      method: HttpMethod.PUT,
+      url: `${baseUrl}/api/user`,
+      headers: {
+        'Authorization': 'Token jwt.token.here',
+        'Content-Type': 'application/json'
+      },
+      body: {
+        user: {
+          email: 'string',
+          username: 'string',
+          password: 'string',
+          bio: 'string',
+          image: 'string'
+        }
+      }
+    });
+
+  await t.notThrowsAsync(promise);
+});

--- a/test/security/put-articles-by-slug.test.js
+++ b/test/security/put-articles-by-slug.test.js
@@ -1,0 +1,74 @@
+const t = require('tap');
+const { SecRunner } = require('@sectester/runner');
+const { TestType, Severity, AttackParamLocation, HttpMethod } = require('@sectester/scan');
+
+let runner;
+let app;
+let baseUrl;
+
+// Setup hooks for initializing the application and SecTester
+
+t.before(async () => {
+  app = require('../../lib/server'); // Adjust the path to the actual server file
+
+  await app.ready();
+
+  baseUrl = app.server.address().port;
+});
+
+t.beforeEach(async () => {
+  runner = new SecRunner({
+    hostname: process.env.BRIGHT_HOSTNAME
+  });
+
+  await runner.init();
+});
+
+t.afterEach(() => runner.clear());
+
+t.after(() => app.close());
+
+// Placeholder for test cases
+
+test('PUT /api/articles/:slug', async t => {
+  const promise = runner
+    .createScan({
+      tests: [
+        TestType.SQLI,
+        TestType.XSS,
+        TestType.CSRF,
+        TestType.BROKEN_ACCESS_CONTROL,
+        TestType.INSECURE_OUTPUT_HANDLING,
+        TestType.MASS_ASSIGNMENT,
+        TestType.EXCESSIVE_DATA_EXPOSURE,
+        TestType.UNVALIDATED_REDIRECT,
+        TestType.JWT,
+        TestType.COOKIE_SECURITY,
+        TestType.STORED_XSS
+      ],
+      attackParamLocations: [
+        AttackParamLocation.BODY,
+        AttackParamLocation.HEADER,
+        AttackParamLocation.PATH
+      ]
+    })
+    .threshold(Severity.LOW)
+    .timeout(15 * 60 * 1000)
+    .run({
+      method: HttpMethod.PUT,
+      url: `${baseUrl}/api/articles/slug`,
+      headers: {
+        'Authorization': 'Token jwt.token.here',
+        'Content-Type': 'application/json'
+      },
+      body: {
+        article: {
+          title: 'string',
+          description: 'string',
+          body: 'string'
+        }
+      }
+    });
+
+  await t.notThrowsAsync(promise);
+});


### PR DESCRIPTION
## Description

Adds security tests for the following endpoints:
- GET http://localhost:3000/api/articles
- GET http://localhost:3000/api/articles/feed
- GET http://localhost:3000/api/articles/:slug
- POST http://localhost:3000/api/articles
- PUT http://localhost:3000/api/articles/:slug
- DELETE http://localhost:3000/api/articles/:slug
- POST http://localhost:3000/api/articles/:slug/favorite
- DELETE http://localhost:3000/api/articles/:slug/favorite
- GET http://localhost:3000/api/articles/:slug/comments
- POST http://localhost:3000/api/articles/:slug/comments
- DELETE http://localhost:3000/api/articles/:slug/comments/:id
- GET http://localhost:3000/api/profiles/:username
- POST http://localhost:3000/api/profiles/:username/follow
- DELETE http://localhost:3000/api/profiles/:username/follow
- POST http://localhost:3000/api/sentiment/score
- GET http://localhost:3000/api/tags
- POST http://localhost:3000/api/users/login
- POST http://localhost:3000/api/users
- GET http://localhost:3000/api/user
- PUT http://localhost:3000/api/user

Tests cover:
- SQL injection
- XSS vulnerabilities
- Authentication bypass

## Test Plan

- Run the security tests using the provided test scripts
- Verify that all tests pass without any security vulnerabilities detected

## Security

- SQL injection checks
- XSS vulnerability checks
- Authentication bypass checks