### PR TITLE
test(security): add security tests for articles endpoints

### DIFF
--- a/.github/workflows/bright.yml
+++ b/.github/workflows/bright.yml
@@ -1,0 +1,42 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - '**'
+
+permissions:
+  checks: write
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    env:
+      BRIGHT_HOSTNAME: ${{ vars.BRIGHT_HOSTNAME }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '16'
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Create .env file
+        run: npm run create:env
+
+      - name: Start application
+        run: npm start &
+        env:
+          PORT: 5000
+
+      - name: Run tests
+        run: npx tap test/sec/*.test.js
+        env:
+          BRIGHT_TOKEN: ${{ secrets.BRIGHT_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_COMMIT_SHA: ${{ github.event.pull_request.head.sha }}

--- a/test/sec/get-articles-feed.test.js
+++ b/test/sec/get-articles-feed.test.js
@@ -1,0 +1,58 @@
+'use strict'
+const t = require('tap')
+const startServer = require('../setup-server')
+const { SecRunner } = require('@sectester/runner')
+const { TestType, Severity, AttackParamLocation, HttpMethod } = require('@sectester/scan')
+
+let runner;
+let server;
+let baseUrl;
+
+t.before(async () => {
+  runner = new SecRunner({
+    hostname: process.env.BRIGHT_HOSTNAME
+  });
+
+  await runner.init();
+
+  server = await startServer();
+  baseUrl = server.server.address().port;
+});
+
+t.afterEach(() => runner.clear());
+
+t.teardown(() => server.close());
+
+t.test('GET /articles/feed', async t => {
+  const promise = runner
+    .createScan({
+      tests: [
+        TestType.SQLI,
+        TestType.XSS,
+        TestType.CSRF,
+        TestType.BROKEN_ACCESS_CONTROL,
+        TestType.EXCESSIVE_DATA_EXPOSURE,
+        TestType.ID_ENUMERATION
+      ],
+      attackParamLocations: [
+        AttackParamLocation.QUERY,
+        AttackParamLocation.HEADER
+      ]
+    })
+    .threshold(Severity.LOW)
+    .timeout(15 * 60 * 1000)
+    .run({
+      method: HttpMethod.GET,
+      url: `${baseUrl}/articles/feed`,
+      headers: {
+        Authorization: 'Token jwt.token.here'
+      },
+      query: {
+        limit: '20',
+        offset: '0'
+      }
+    });
+
+  t.rejects(promise)
+  t.end()
+});

--- a/test/sec/get-articles.test.js
+++ b/test/sec/get-articles.test.js
@@ -1,0 +1,48 @@
+'use strict'
+const t = require('tap')
+const startServer = require('../setup-server')
+const { SecRunner } = require('@sectester/runner')
+const { TestType, Severity, AttackParamLocation, HttpMethod } = require('@sectester/scan')
+
+let runner;
+let server;
+let baseUrl;
+
+t.before(async () => {
+  runner = new SecRunner({
+    hostname: process.env.BRIGHT_HOSTNAME
+  });
+
+  await runner.init();
+
+  server = await startServer();
+  baseUrl = `http://localhost:${server.server.address().port}`;
+});
+
+t.afterEach(() => runner.clear());
+
+t.teardown(() => server.close());
+
+t.test('GET /articles', async t => {
+  const promise = runner
+    .createScan({
+      tests: [TestType.SQLI, TestType.XSS, TestType.EXCESSIVE_DATA_EXPOSURE, TestType.ID_ENUMERATION, TestType.HTTP_METHOD_FUZZING],
+      attackParamLocations: [AttackParamLocation.QUERY]
+    })
+    .threshold(Severity.LOW)
+    .timeout(15 * 60 * 1000)
+    .run({
+      method: HttpMethod.GET,
+      url: `${baseUrl}/articles`,
+      query: {
+        tag: 'string',
+        author: 'string',
+        favorited: 'string',
+        limit: '20',
+        offset: '0'
+      }
+    });
+
+  t.rejects(promise)
+  t.end()
+});


### PR DESCRIPTION
## Description

Adds security tests for the following endpoints:
- GET http://localhost:3000/articles
- GET http://localhost:3000/articles/feed

Tests cover:
- SQL injection
- XSS vulnerabilities
- Authentication bypass

## Test Plan

- Run the security tests using the provided test scripts
- Verify that all tests pass without any security vulnerabilities detected

## Security

- SQL injection checks
- XSS vulnerability checks
- Authentication bypass checks