### PR TITLE
test: add security tests for articles endpoints

### DIFF
--- a/.github/workflows/bright.yml
+++ b/.github/workflows/bright.yml
@@ -1,0 +1,37 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - '**'
+
+permissions:
+  checks: write
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    env:
+      BRIGHT_HOSTNAME: ${{ vars.BRIGHT_HOSTNAME }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '16'
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Create .env file
+        run: npm run create:env
+
+      - name: Run tests
+        run: npx tap test/security/*.test.js
+        env:
+          BRIGHT_TOKEN: ${{ secrets.BRIGHT_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_COMMIT_SHA: ${{ github.event.pull_request.head.sha }}

--- a/test/security/get-articles-feed.test.js
+++ b/test/security/get-articles-feed.test.js
@@ -1,0 +1,52 @@
+'use strict'
+const t = require('tap')
+const { SecRunner } = require('@sectester/runner')
+const startServer = require('../../setup-server')
+const { TestType, Severity, AttackParamLocation, HttpMethod } = require('@sectester/scan')
+
+let runner;
+let server;
+let baseUrl;
+
+t.beforeEach(async () => {
+  runner = new SecRunner({
+    hostname: process.env.BRIGHT_HOSTNAME
+  });
+  await runner.init();
+
+  server = await startServer();
+  baseUrl = await server.listen({ port: 0 });
+});
+
+t.afterEach(async () => {
+  await runner.clear();
+  await server.close();
+});
+
+t.test('GET /articles/feed', async t => {
+  t.setTimeout(15 * 60 * 1000);
+
+  const promise = runner
+    .createScan({
+      tests: [
+        TestType.BROKEN_ACCESS_CONTROL,
+        TestType.CSRF,
+        TestType.EXCESSIVE_DATA_EXPOSURE,
+        TestType.HTTP_METHOD_FUZZING,
+        TestType.ID_ENUMERATION,
+        TestType.JWT,
+        TestType.SQLI
+      ],
+      attackParamLocations: [AttackParamLocation.QUERY, AttackParamLocation.HEADER]
+    })
+    .threshold(Severity.LOW)
+    .timeout(15 * 60 * 1000)
+    .run({
+      method: HttpMethod.GET,
+      url: `${baseUrl}/articles/feed`,
+      headers: { Authorization: 'Token jwt.token.here' },
+      query: { limit: '20', offset: '0' }
+    });
+
+  await t.resolves(promise);
+});

--- a/test/security/get-articles.test.js
+++ b/test/security/get-articles.test.js
@@ -1,0 +1,53 @@
+'use strict'
+const t = require('tap')
+const { SecRunner } = require('@sectester/runner')
+const startServer = require('../../setup-server')
+
+let runner;
+let server;
+let baseUrl;
+
+t.beforeEach(async () => {
+  runner = new SecRunner({
+    hostname: process.env.BRIGHT_HOSTNAME
+  });
+  await runner.init();
+
+  server = await startServer();
+  baseUrl = await server.listen({ port: 0 });
+});
+
+t.afterEach(async () => {
+  await runner.clear();
+  await server.close();
+});
+
+t.test('GET /articles', async t => {
+  t.setTimeout(15 * 60 * 1000);
+
+  const promise = runner
+    .createScan({
+      tests: [
+        'sqli',
+        'xss',
+        'excessive_data_exposure',
+        'id_enumeration'
+      ],
+      attackParamLocations: ['query']
+    })
+    .threshold('LOW')
+    .timeout(15 * 60 * 1000)
+    .run({
+      method: 'GET',
+      url: `${baseUrl}/articles`,
+      query: {
+        tag: 'string',
+        author: 'string',
+        favorited: 'string',
+        limit: '20',
+        offset: '0'
+      }
+    });
+
+  await t.resolves(promise);
+});


### PR DESCRIPTION
## Description

Adds security tests for the following endpoints:
- GET http://localhost:3000/articles
- GET http://localhost:3000/articles/feed

Tests cover:
- SQL injection
- XSS vulnerabilities
- Authentication bypass

## Test Plan

- Run the security tests using the provided test scripts
- Verify that all tests pass without any security vulnerabilities detected

## Security

- SQL injection checks
- XSS vulnerability checks
- Authentication bypass checks