### PR TITLE
test: add security tests for articles endpoints

### DIFF
--- a/.github/workflows/bright.yml
+++ b/.github/workflows/bright.yml
@@ -1,0 +1,37 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - '**'
+
+permissions:
+  checks: write
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    env:
+      BRIGHT_HOSTNAME: ${{ vars.BRIGHT_HOSTNAME }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '16'
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Create .env file
+        run: npm run create:env
+
+      - name: Run tests
+        run: npx tap test/security/*.test.js
+        env:
+          BRIGHT_TOKEN: ${{ secrets.BRIGHT_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_COMMIT_SHA: ${{ github.event.pull_request.head.sha }}

--- a/test/security/get-articles-feed.test.js
+++ b/test/security/get-articles-feed.test.js
@@ -1,0 +1,44 @@
+'use strict'
+const t = require('tap')
+const { SecRunner, TestType, Severity, HttpMethod, AttackParamLocation } = require('@sectester/runner')
+const startServer = require('../../setup-server')
+
+let runner;
+let server;
+let baseUrl;
+
+t.before(async () => {
+  server = await startServer();
+  baseUrl = await server.listen({ port: 0 });
+});
+
+t.beforeEach(async () => {
+  runner = new SecRunner({
+    hostname: process.env.BRIGHT_HOSTNAME
+  });
+  await runner.init();
+});
+
+t.afterEach(() => runner.clear());
+
+t.teardown(() => server.close());
+
+t.test('GET /api/articles/feed', async t => {
+  t.setTimeout(15 * 60 * 1000);
+
+  const promise = runner
+    .createScan({
+      tests: [TestType.JWT, TestType.EXCESSIVE_DATA_EXPOSURE, TestType.ID_ENUMERATION, TestType.HTTP_METHOD_FUZZING],
+      attackParamLocations: [AttackParamLocation.QUERY, AttackParamLocation.HEADER]
+    })
+    .threshold(Severity.LOW)
+    .timeout(15 * 60 * 1000)
+    .run({
+      method: HttpMethod.GET,
+      url: `${baseUrl}/api/articles/feed`,
+      headers: { Authorization: 'Token jwt.token.here' },
+      query: { limit: '20', offset: '0' }
+    });
+
+  await t.resolves(promise);
+});

--- a/test/security/get-articles-feed.test.js
+++ b/test/security/get-articles-feed.test.js
@@ -1,7 +1,7 @@
 'use strict'
 const t = require('tap')
 const { SecRunner, TestType, Severity, HttpMethod, AttackParamLocation } = require('@sectester/runner')
-const startServer = require('../../setup-server')
+const startServer = require('../setup-server')
 
 let runner;
 let server;
@@ -23,8 +23,9 @@ t.afterEach(() => runner.clear());
 
 t.teardown(() => server.close());
 
+t.setTimeout(15 * 60 * 1000);
+
 t.test('GET /api/articles/feed', async t => {
-  t.setTimeout(15 * 60 * 1000);
 
   const promise = runner
     .createScan({

--- a/test/security/get-articles.test.js
+++ b/test/security/get-articles.test.js
@@ -24,8 +24,9 @@ t.afterEach(() => runner.clear());
 
 t.teardown(() => server.close());
 
+t.setTimeout(15 * 60 * 1000);
+
 t.test('GET /api/articles', async t => {
-  t.setTimeout(15 * 60 * 1000);
 
   const promise = runner
     .createScan({

--- a/test/security/get-articles.test.js
+++ b/test/security/get-articles.test.js
@@ -1,0 +1,50 @@
+'use strict'
+const t = require('tap')
+const { SecRunner } = require('@sectester/runner')
+const { TestType, Severity, AttackParamLocation, HttpMethod } = require('@sectester/scan')
+const startServer = require('../setup-server')
+
+let runner;
+let server;
+let baseUrl;
+
+t.before(async () => {
+  server = await startServer();
+  baseUrl = await server.listen({ port: 0 });
+});
+
+t.beforeEach(async () => {
+  runner = new SecRunner({
+    hostname: process.env.BRIGHT_HOSTNAME
+  });
+  await runner.init();
+});
+
+t.afterEach(() => runner.clear());
+
+t.teardown(() => server.close());
+
+t.test('GET /api/articles', async t => {
+  t.setTimeout(15 * 60 * 1000);
+
+  const promise = runner
+    .createScan({
+      tests: [TestType.SQLI, TestType.XSS, TestType.EXCESSIVE_DATA_EXPOSURE, TestType.ID_ENUMERATION],
+      attackParamLocations: [AttackParamLocation.QUERY]
+    })
+    .threshold(Severity.LOW)
+    .timeout(15 * 60 * 1000)
+    .run({
+      method: HttpMethod.GET,
+      url: `${baseUrl}/api/articles`,
+      query: {
+        tag: 'example',
+        author: 'example',
+        favorited: 'example',
+        limit: '20',
+        offset: '0'
+      }
+    });
+
+  await t.resolves(promise);
+});


### PR DESCRIPTION
## Description

Adds security tests for the following endpoints:
- GET http://localhost:3000/api/articles
- GET http://localhost:3000/api/articles/feed

Tests cover:
- SQL injection
- XSS vulnerabilities
- Authentication bypass

## Test Plan

- Run the security tests using the provided test scripts
- Verify that all tests pass without any security vulnerabilities detected

## Security

- SQL injection checks
- XSS vulnerability checks
- Authentication bypass checks